### PR TITLE
Update the code that checks for package updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ ______________________________________________________________________
 
 Things to be included in the next release go here.
 
+### Fixed
+
+- Fixed a potential `PermissionsError` crash that occurred when trying to check for any available package updates
+
+### Added
+
+- A config flag to enable checking for updates when creating a new instance of the `DeviceManager`
+
+### Changed
+
+- The default behavior of the `DeviceManager` is changed to **not** check for updates
+
 ______________________________________________________________________
 
 ## v0.1.18 (2023-10-23)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,6 +216,7 @@ options:
   setup_cleanup: false
   teardown_cleanup: false
   retry_visa_connection: false
+  check_for_updates: false
 ```
 
 These are all `false` by default if not defined, set to `true` to modify the
@@ -239,6 +240,9 @@ runtime behavior configuration.
 - `retry_visa_connection`
   - This config option will enable a second attempt when creating VISA connections,
     the second attempt is made after waiting, to allow the device time to become available.
+- `check_for_updates`
+  - This config option will enable a check for any available updates on pypi.org for the
+    package when the `DeviceManager` is instantiated.
 
 ### Sample Config File
 
@@ -293,6 +297,7 @@ options:
   verbose_mode: false
   verbose_visa: false
   retry_visa_connection: false
+  check_for_updates: false
 ```
 
 #### TOML
@@ -358,6 +363,7 @@ standalone = false
 verbose_mode = false
 verbose_visa = false
 retry_visa_connection = false
+check_for_updates = false
 ```
 
 ______________________________________________________________________

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ repository = "https://github.com/tektronix/tm_devices"
 version = "0.1.18"
 
 [tool.poetry.dependencies]
-check4updates = ">=0.0.2"
 gpib-ctypes = ">=0.3.0"
 libusb-package = ">=1.0.26.0,!=1.0.26.2"  # 1.0.26.2 doesn't work with Python 3.12
 packaging = ">=21.3"

--- a/scripts/pypi_latest_version.py
+++ b/scripts/pypi_latest_version.py
@@ -26,6 +26,7 @@ def parse_arguments() -> argparse.Namespace:
         action="store",
         dest="index",
         choices=["pypi", "test.pypi"],
+        default="pypi",
         help="Provide the index to query for the latest version, one of (pypi|test.pypi)",
     )
 
@@ -42,6 +43,8 @@ def main() -> None:
     package = args.package
     index = args.index
 
+    # This code mirrors code found in src/tm_devices/helpers/functions.py.
+    # If this code is updated, the helper function should be updated too.
     url = f"https://{index}.org/pypi/{package}/json"
     try:
         response = requests.get(url, timeout=10)

--- a/src/tm_devices/device_manager.py
+++ b/src/tm_devices/device_manager.py
@@ -274,7 +274,6 @@ class DeviceManager(metaclass=Singleton):
                 (updates the current configuration options).
             external_device_drivers: An optional dict for passing in additional device drivers.
         """
-        check_for_update()
         self._suppress_protection = False
         # Set up the DeviceManager
         self.__is_open = False
@@ -284,6 +283,8 @@ class DeviceManager(metaclass=Singleton):
         self.__config = DMConfigParser()
         if config_options is not None:
             self.__config.update_options(config_options)
+        if self.__config.options.check_for_updates:  # pragma: no cover
+            check_for_update()
 
         # initialize for __set_options
         self.__verbose: bool = NotImplemented

--- a/src/tm_devices/helpers/constants_and_dataclasses.py
+++ b/src/tm_devices/helpers/constants_and_dataclasses.py
@@ -377,6 +377,8 @@ class DMConfigOptions(AsDictionaryMixin):
     """Optional[bool]: A verbosity flag to enable extremely verbose VISA logging to stdout."""
     retry_visa_connection: Optional[bool] = None
     """Optional[bool]: A flag to enable retrying the first VISA connection attempt."""
+    check_for_updates: Optional[bool] = None
+    """Optional[bool]: A flag indicating if a check for updates for the package should be performed on creation of the DeviceManager."""  # noqa: E501
 
     def __str__(self) -> str:
         """Complete config entry line for an environment variable."""

--- a/src/tm_devices/helpers/functions.py
+++ b/src/tm_devices/helpers/functions.py
@@ -70,7 +70,7 @@ def check_for_update(package_name: str = PACKAGE_NAME, index_name: str = "pypi")
 
         # Get the version from the index
         # This code mirrors code found in scripts/pypi_latest_version.py.
-        # If this code is updated, the helper function should be updated too.
+        # If this code is updated, the script should be updated too.
         url = f"https://{index_name}.org/pypi/{package_name}/json"
         response = requests.get(url, timeout=10)
         releases = json.loads(response.text)["releases"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,12 @@ import pyvisa.constants
 
 from mock_server import mocker_server, PORT
 from tm_devices import DeviceManager
+from tm_devices.components import DMConfigParser
 from tm_devices.helpers import validate_address
 
 os.environ["TM_DEVICES_UNIT_TESTS_RUNNING"] = "true"
+# Make sure to not use any local config files
+os.environ[DMConfigParser.CONFIG_FILE_PATH_ENV_VARIABLE] = ""
 
 PROJECT_ROOT_DIR = f"{os.path.dirname(os.path.dirname(__file__))}"
 SIMULATED_VISA_LIB = f"{os.path.dirname(__file__)}/sim_devices/devices.yaml@sim"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -286,21 +286,21 @@ def test_check_for_update(capsys: pytest.CaptureFixture[str]) -> None:
     with mock.patch("requests.get", mock.MagicMock(return_value=response)):
         check_for_update("pytest")
     stdout = capsys.readouterr().out
-    assert "pytest is not available on PyPI, unable to check for updates." in stdout
+    assert "pytest is not available on pypi.org, unable to check for updates." in stdout
 
     # Test when an update is available
     response = Response()
-    response._content = b">pytest-0.0.0.tar.gz<"  # noqa: SLF001
+    response._content = b'{"releases": {"0.0.0": []}}'  # noqa: SLF001
     with mock.patch("requests.get", mock.MagicMock(return_value=response)):
         check_for_update("pytest")
     stdout = capsys.readouterr().out
-    assert "Version 0.0.0 of pytest is available on PyPI." in stdout
+    assert "Version 0.0.0 of pytest is available on pypi.org." in stdout
     assert f"Version {pytest.__version__} of pytest is currently installed." in stdout
     assert "To upgrade pytest run the following command: python -m pip install -U pytest" in stdout
 
     # Test when the versions match
     response = Response()
-    response._content = f">pytest-{pytest.__version__}.tar.gz<".encode()  # noqa: SLF001
+    response._content = f'{{"releases": {{"{pytest.__version__}": []}}}}'.encode()  # noqa: SLF001
     with mock.patch("requests.get", mock.MagicMock(return_value=response)):
         check_for_update("pytest")
     stdout = capsys.readouterr().out


### PR DESCRIPTION
fix: Replaced a third-party package used to check for updates with a few lines of code to perform a request and parse the returned json. This prevents a PermissionsError from happening on some systems. Also added a flag to enable the check for updates, it now defaults to off.

## Proposed changes

This fixes a potential `PermissionsError` by replacing a third-party package with a direct usage of `requests.get()`. A config option was added, defaulting to `False`, that can enable a check for updates when the `DeviceManager` is first instantiated if the user wants to have that behavior.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
