### PR TITLE
Increase timeout value when installing tm_devices from pypi servers

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -150,7 +150,7 @@ jobs:
         # A retry is used to allow for some downtime before the package is installable
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 2
+          timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 30
           warning_on_retry: false

--- a/.github/workflows/package-testpypi.yml
+++ b/.github/workflows/package-testpypi.yml
@@ -68,7 +68,7 @@ jobs:
         # A retry is used to allow for some downtime before the package is installable
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 2
+          timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 30
           warning_on_retry: false


### PR DESCRIPTION
## Proposed changes

ci: Increase timeout when installing tm_devices from pypi servers to avoid issues caused by long wheel build times for packages that tm_devices depends on (such as zeroconf).

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
