### PR TITLE
feat: Added a mechanism to reset cached properties whenever a device is rebooted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ ______________________________________________________________________
 
 Things to be included in the next release go here.
 
+### Added
+
+- Added a step during a device reboot that will reset all the cached properties in the event that one of them changed.
+
 ### Changed
 
 - Switched to ruff's formatter instead of black's formatter for python code

--- a/tests/test_afgs.py
+++ b/tests/test_afgs.py
@@ -124,8 +124,18 @@ def test_afg31k(device_manager: DeviceManager, capsys: pytest.CaptureFixture[str
     afg31k = device_manager.add_afg("afg31k-hostname")
 
     _ = capsys.readouterr().out  # throw away stdout
+
+    # Check hostname
+    assert afg31k.hostname == "AFG31K-HOSTNAME"
+    # Change hostname to test the reset of cached properties
+    afg31k.hostname = "temp-hostname"
+    assert afg31k.hostname == "temp-hostname"
+
     # simulate a reboot
     afg31k.reboot()
+
+    # Test that the cached property was reset
+    assert afg31k.hostname == "AFG31K-HOSTNAME"
 
     stdout = capsys.readouterr().out
     assert "SYSTem:RESTart" in stdout


### PR DESCRIPTION
## Proposed changes

When a device is rebooted some properties may change. In order to prevent this from causing issues, a mechanism was added to the `reboot()` method that will reset all cached properties when `.reboot()` is called.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Functionality update (non-breaking change which updates or changes existing functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
