### PR TITLE
Handle Visa IO Error on first connection

### DIFF
--- a/src/tm_devices/device_manager.py
+++ b/src/tm_devices/device_manager.py
@@ -1091,8 +1091,8 @@ class DeviceManager(metaclass=Singleton):
             visa_resource.clear()
         except visa.VisaIOError as e:
             warnings.warn(
-                f"A visa IO error occurred when attempting to read the status byte or clear the "
-                f"ouptut buffer of the resource `{visa_resource.resource_info.resource_name}`.\n"
+                f"A VISA IO error occurred when attempting to read the status byte or clear the "
+                f"output buffer of the resource `{visa_resource.resource_info.resource_name}`.\n"
                 f"Error: {e}",
                 stacklevel=1,
             )

--- a/src/tm_devices/device_manager.py
+++ b/src/tm_devices/device_manager.py
@@ -1072,20 +1072,30 @@ class DeviceManager(metaclass=Singleton):
         Raises:
             SystemError: Indicates that the buffer was unable to be cleared.
         """
-        if 16 & visa_resource.read_stb():
-            # 16 is the MAV bit (Message Available) from the Status Byte register
-            # MAV flag is only one bit and turns off after a single response is successfully read,
-            # even if there's more in the buffer
+        # use a try-except block to avoid any errors caused by Visa instruments that may not
+        # respond correctly to the read_stb or clear functions.
+        try:
+            if 16 & visa_resource.read_stb():
+                # 16 is the MAV bit (Message Available) from the Status Byte register
+                # MAV flag is only one bit and turns off after a single response is
+                # successfully read, even if there is more in the buffer.
+                warnings.warn(
+                    f"\nThe device `{visa_resource.resource_info.resource_name}` had data "
+                    "sitting in the VISA Output Buffer on first connection. "
+                    "\nDetected data in the buffer via the Status Byte register. "
+                    "\nThe device_clear() will be called so VISA I/O buffers get flushed.",
+                    stacklevel=1,
+                )
+            # always flush the VISA I/O Buffers on the device to clean up any stale data.
+            # (note: the Events are kept in different buffers, so *ESR? is not impacted)
+            visa_resource.clear()
+        except visa.VisaIOError as e:
             warnings.warn(
-                f"\nThe device `{visa_resource.resource_info.resource_name}` had data "
-                "sitting in the VISA Output Buffer on first connection. "
-                "\nDetected data in the buffer via the Status Byte register. "
-                "\nThe device_clear() will be called so VISA I/O buffers get flushed.",
+                f"A visa IO error occurred when attempting to read the status byte or clear the "
+                f"ouptut buffer of the resource `{visa_resource.resource_info.resource_name}`.\n"
+                f"Error: {e}",
                 stacklevel=1,
             )
-        # always flush the VISA I/O Buffers on the device to clean up any stale data.
-        # (note: the Events are kept in different buffers, so *ESR? is not impacted)
-        visa_resource.clear()
         visa_resource.write("*IDN?")
         idn_response = ""
         error_msg = None


### PR DESCRIPTION
## Proposed changes

On first connection the check for `visa_resource.read_stb()` to detect messages left in the output buffer and `visa_resource.clear()` calls will print a warning instead of instantly failing if the visa driver or the device don't fully support those calls. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
