### PR TITLE
Fix ReadtheDocs builds by installing nodejs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: '3.11'  # This needs to stay in sync with pyproject.toml and any CI scripts
+    nodejs: '20'  # This needs to stay in sync with any CI scripts
 python:
   install:
     - requirements: docs/requirements.txt

--- a/src/tm_devices/components/dm_config_parser.py
+++ b/src/tm_devices/components/dm_config_parser.py
@@ -7,7 +7,6 @@ import dataclasses
 import os
 import pathlib
 
-from dataclasses import dataclass
 from types import MappingProxyType
 from typing import (
     Any,
@@ -43,7 +42,7 @@ from tm_devices.helpers.constants_and_dataclasses import (
 
 
 @runtime_checkable
-@dataclass
+@dataclasses.dataclass
 class _DataclassProtocol(Protocol):
     """A Protocol class to allow for type hinting things that accept generic dataclasses."""
 


### PR DESCRIPTION
## Proposed changes

ReadtheDocs builds are failing because Nodejs is not installed.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [x] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
