### PR TITLE
ci: Revert python-semantic-release version bump since the GitHub Action no longer properly signs commits

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -82,7 +82,7 @@ jobs:
           python scripts/check_unreleased_changelog_items.py
           git config --global tag.gpgSign true
       - name: Python Semantic Release
-        uses: python-semantic-release/python-semantic-release@v9.7.0
+        uses: python-semantic-release/python-semantic-release@v9.6.0
         id: release
         with:
           force: ${{ inputs.release_level }}


### PR DESCRIPTION
## Proposed changes

The most recent release of `python-semantic-release` no longer properly signs commits, presumably due to https://github.com/python-semantic-release/python-semantic-release/issues/918. This PR reverts back to the previous versino of `python-semantic-release`.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)7
- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)7

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
