### PR TITLE
docs: Update copy code button to not show up on doc signatures in the API documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Valid subsections within a version are:
 
 Things to be included in the next release go here.
 
+### Removed
+
+- docs: Removed the copy code button from the Python API signatures in the documentation.
+
 ---
 
 ## v1.4.2 (2024-05-09)

--- a/docs/_static/js/copybutton.js
+++ b/docs/_static/js/copybutton.js
@@ -123,7 +123,7 @@ const addCopyButtonToCodeCells = () => {
   }
 
   // Add copybuttons to all of our code cells
-  const COPYBUTTON_SELECTOR = 'div.highlight pre';
+  const COPYBUTTON_SELECTOR = 'div.highlight:not(.doc-signature) pre';
   const codeCells = document.querySelectorAll(COPYBUTTON_SELECTOR)
   codeCells.forEach((codeCell, index) => {
     const id = codeCellId(index)
@@ -218,7 +218,6 @@ var copyTargetText = (trigger) => {
   let exclude = '.linenos';  // Can use ".linenos, .gp, .go" to exclude prompt characters and output in code blocks
 
   let text = filterText(target, exclude);
-  // return formatCopyText(text, {{ "{!r}".format(copybutton_prompt_text) }}, {{ copybutton_prompt_is_regexp | lower }}, {{ copybutton_only_copy_prompt_lines | lower }}, {{ copybutton_remove_prompts | lower }}, {{ copybutton_copy_empty_lines | lower }}, {{ "{!r}".format(copybutton_line_continuation_character) }}, {{ "{!r}".format(copybutton_here_doc_delimiter) }})
   return formatCopyText(text, "", false, true, true, true, "", "")
 }
 


### PR DESCRIPTION
## Proposed changes

Removed the copy code button from the signatures in the API documentation, since there is never a need to copy that code, it is just for readability and nicely formatted links.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
