### PR TITLE
Add workflows to check for changes that break public APIs

### DIFF
--- a/.github/workflows/check-api-for-breaking-changes.yml
+++ b/.github/workflows/check-api-for-breaking-changes.yml
@@ -1,0 +1,42 @@
+---
+name: Check Public API for Breaking Changes
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
+    inputs:
+      package-name:
+        description: The name of the package to check.
+        required: true
+        type: string
+jobs:
+  check-api-for-breaking-changes:
+    name: Check API for breaking changes
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_NAME: ${{ inputs.package-name || 'tm_devices' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: x  # any version
+          check-latest: true
+      - name: Install package to check
+        run: |
+          pip install --upgrade .
+          pip install griffe
+      - name: Check API for breaking changes
+        continue-on-error: true
+        run: |
+          echo "## Breaking API Changes" > breaking_changes.md
+          echo "\`\`\`" >> breaking_changes.md
+          griffe check --format=verbose --against=$(git rev-parse origin/main) --search=src "$PACKAGE_NAME" 2>&1 | tee -a breaking_changes.md
+      - name: Finish writing summary file
+        run: echo "\`\`\`" >> breaking_changes.md
+      - uses: actions/upload-artifact@v4
+        with:
+          name: breaking_changes
+          path: breaking_changes.md

--- a/.github/workflows/publish-api-comparison.yml
+++ b/.github/workflows/publish-api-comparison.yml
@@ -27,6 +27,8 @@ jobs:
           else
             echo "breaking_changes=true" >> $GITHUB_OUTPUT
           fi
+      - name: debug output
+        run: echo ${{ steps.check.breaking_changes }}
       - name: Fetch PR number
         id: pr
         uses: actions/github-script@v7

--- a/.github/workflows/publish-api-comparison.yml
+++ b/.github/workflows/publish-api-comparison.yml
@@ -1,0 +1,53 @@
+---
+name: Publish API Breaking Change Check Results
+on:
+  workflow_run:
+    workflows: [Check Public API for Breaking Changes]
+    types: [completed]
+  workflow_call:
+jobs:
+  publish-test-results:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && !contains(fromJSON('["skipped", "cancelled"]'), github.event.workflow_run.conclusion) }}
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Download and Extract Artifacts
+        uses: dawidd6/action-download-artifact@v3.1.4
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: breaking_changes
+          path: artifacts
+      - name: Fetch PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const response = await github.rest.search.issuesAndPullRequests({
+              q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',
+              per_page: 1,
+            })
+            const items = response.data.items
+            if (items.length < 1) {
+              console.error('No PRs found')
+              return
+            }
+            const pullRequestNumber = items[0].number
+            console.info("Pull request number is", pullRequestNumber)
+            return pullRequestNumber
+      - name: Publish API Breaking Changes Check Results
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: breaking-api-changes
+          number: ${{ steps.pr.outputs.result }}
+          recreate: true
+          path: artifacts/breaking_changes.md
+      - name: Add workflow link to comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: breaking-api-changes
+          number: ${{ steps.pr.outputs.result }}
+          append: true
+          message: |-
+            <p><a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}">Link to workflow run</a></p>

--- a/.github/workflows/publish-api-comparison.yml
+++ b/.github/workflows/publish-api-comparison.yml
@@ -19,6 +19,14 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           name: breaking_changes
           path: artifacts
+      - name: Check for breaking changes
+        id: check
+        run: |
+          if grep -Pzl '\n```\n```' artifacts/breaking_changes.md; then
+            echo "breaking_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "breaking_changes=true" >> $GITHUB_OUTPUT
+          fi
       - name: Fetch PR number
         id: pr
         uses: actions/github-script@v7
@@ -38,12 +46,14 @@ jobs:
             return pullRequestNumber
       - name: Publish API Breaking Changes Check Results
         uses: marocchino/sticky-pull-request-comment@v2
+        if: steps.check.breaking_changes == 'true'
         with:
           header: breaking-api-changes
           number: ${{ steps.pr.outputs.result }}
           recreate: true
           path: artifacts/breaking_changes.md
       - name: Add workflow link to comment
+        if: steps.check.breaking_changes == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: breaking-api-changes
@@ -51,3 +61,9 @@ jobs:
           append: true
           message: |-
             <p><a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}">Link to workflow run</a></p>
+      - name: Delete comment if no breaking changes are found
+        if: steps.check.breaking_changes == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: breaking-api-changes
+          delete: true

--- a/.github/workflows/publish-api-comparison.yml
+++ b/.github/workflows/publish-api-comparison.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-test-results:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.event == 'pull_request' && !contains(fromJSON('["skipped", "cancelled"]'), github.event.workflow_run.conclusion) }}
+    if: ${{ github.event.workflow_run.event == 'pull_request' && !contains(fromJSON('["skipped", "cancelled", "failed"]'), github.event.workflow_run.conclusion) }}
     permissions:
       checks: write
       pull-requests: write

--- a/.github/workflows/publish-api-comparison.yml
+++ b/.github/workflows/publish-api-comparison.yml
@@ -20,15 +20,14 @@ jobs:
           name: breaking_changes
           path: artifacts
       - name: Check for breaking changes
-        id: check
         run: |
           if grep -Pzl '\n```\n```' artifacts/breaking_changes.md; then
-            echo "breaking_changes=false" >> $GITHUB_OUTPUT
+            echo "BREAKING_CHANGES=false" >> $GITHUB_ENV
           else
-            echo "breaking_changes=true" >> $GITHUB_OUTPUT
+            echo "BREAKING_CHANGES=true" >> $GITHUB_ENV
           fi
       - name: debug output
-        run: echo ${{ steps.check.breaking_changes }}
+        run: echo ${{ env.BREAKING_CHANGES }}
       - name: Fetch PR number
         id: pr
         uses: actions/github-script@v7
@@ -48,14 +47,14 @@ jobs:
             return pullRequestNumber
       - name: Publish API Breaking Changes Check Results
         uses: marocchino/sticky-pull-request-comment@v2
-        if: steps.check.breaking_changes == 'true'
+        if: ${{ env.BREAKING_CHANGES == 'true' }}
         with:
           header: breaking-api-changes
           number: ${{ steps.pr.outputs.result }}
           recreate: true
           path: artifacts/breaking_changes.md
       - name: Add workflow link to comment
-        if: steps.check.breaking_changes == 'true'
+        if: ${{ env.BREAKING_CHANGES == 'true' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: breaking-api-changes
@@ -64,7 +63,7 @@ jobs:
           message: |-
             <p><a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}">Link to workflow run</a></p>
       - name: Delete comment if no breaking changes are found
-        if: steps.check.breaking_changes == 'false'
+        if: ${{ env.BREAKING_CHANGES == 'false' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: breaking-api-changes

--- a/.github/workflows/publish-api-comparison.yml
+++ b/.github/workflows/publish-api-comparison.yml
@@ -26,8 +26,6 @@ jobs:
           else
             echo "BREAKING_CHANGES=true" >> $GITHUB_ENV
           fi
-      - name: debug output
-        run: echo ${{ env.BREAKING_CHANGES }}
       - name: Fetch PR number
         id: pr
         uses: actions/github-script@v7
@@ -67,4 +65,5 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: breaking-api-changes
+          number: ${{ steps.pr.outputs.result }}
           delete: true


### PR DESCRIPTION
## Proposed changes

This adds workflows that will check if any public APIs have been broken in a Pull Request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
