### PR TITLE
Enable customizing the default visa timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,14 @@ Valid subsections within a version are:
 
 Things to be included in the next release go here.
 
+### Added
+
+- Added a config option (`default_visa_timeout`) to specify the default VISA timeout for all initial VISA device connections.
+
 ### Changed
 
 - Switched all workflows to use the new [`tektronix/python-package-ci-cd`](https://github.com/tektronix/python-package-ci-cd) reusable workflows.
+- Reduced the out-of-the box `default_visa_timeout` value from 30 seconds to 5 seconds.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ things change, but does not require modification with every script execution.
 
 A config file can be **overruled** by an
 [environment variable](#environment-variable) configuration. That means that if
-you have both a config file defined and the environment variables set, the
+you have both a config file defined and **either** of the environment variables set, the
 config parser will **always** prioritize the environment variables. Make sure to
 delete the environment variables if you want to switch back to the config file.
 
@@ -228,6 +228,7 @@ options:
   setup_cleanup: false
   teardown_cleanup: false
   retry_visa_connection: false
+  default_visa_timeout: 5000
   check_for_updates: false
 ```
 
@@ -252,6 +253,9 @@ runtime behavior configuration.
 - `retry_visa_connection`
     - This config option will enable a second attempt when creating VISA connections,
         the second attempt is made after waiting, to allow the device time to become available.
+- `default_visa_timeout`
+    - This config option is used to set the default VISA timeout value in milliseconds.
+        The default value of this config option is 5000 ms.
 - `check_for_updates`
     - This config option will enable a check for any available updates on pypi.org for the
         package when the `DeviceManager` is instantiated.
@@ -314,6 +318,7 @@ options:
   verbose_mode: false
   verbose_visa: false
   retry_visa_connection: false
+  default_visa_timeout: 10000  # 10 second default VISA timeout
   check_for_updates: false
 ```
 
@@ -388,6 +393,7 @@ standalone = false
 verbose_mode = false
 verbose_visa = false
 retry_visa_connection = false
+default_visa_timeout = 10000  # 10 second default VISA timeout
 check_for_updates = false
 ```
 
@@ -399,7 +405,9 @@ Two environment variables, `TM_OPTIONS` and `TM_DEVICES`, can be used for
 runtime configurations and have a **HIGHER** priority than the config file.
 
 - `TM_OPTIONS` is a comma-delimited, all-uppercase list of enabled options
-    names.
+    names and values. Config options that act as boolean flags can be set simply by
+    adding the option name to the environment variable. Config options that require non-boolean
+    inputs should be specified with the option name followed by an equals sign and the value.
 - `TM_DEVICES` is a `~~~`-delimited list of device entries.
     - Each device entry is a comma-delimited list of `<key>=<value>` pairs.
 
@@ -409,8 +417,8 @@ execution scenarios where the list of devices needs to be temporary and
 workspace variables can be changed easily per script executor.
 
 There is no mechanism for merging the options and devices between the two config
-methods; if either of the `TM_DEVICES` or `TM_OPTIONS` environment variables is
-defined, the config file is ignored. If the environment variable(s) exist,
+methods; if **either** of the `TM_DEVICES` or `TM_OPTIONS` environment variables is
+defined, the config file is completely ignored. If **either** of the environment variable(s) exist,
 either permanently or temporarily, for the lifetime of the shell instance, they
 will override any existing config file you have.
 
@@ -424,8 +432,8 @@ environment variable)
 TM_OPTIONS = "STANDALONE"
 TM_DEVICES = "address=123.45.67.255,device_type=SMU"
 
-# Sample scope using hostname and AFG using IP address with cleanup
-TM_OPTIONS = "SETUP_CLEANUP,TEARDOWN_CLEANUP"
+# Sample scope using hostname and AFG using IP address with cleanup and a non-standard default VISA timeout
+TM_OPTIONS = "SETUP_CLEANUP,TEARDOWN_CLEANUP,DEFAULT_VISA_TIMEOUT=10000"
 TM_DEVICES = "address=MDO9876-C543210,device_type=SCOPE~~~address=123.45.67.255,device_type=AFG"
 
 # Sample scope using IP address and AWG using hostname

--- a/docs/known_words.txt
+++ b/docs/known_words.txt
@@ -55,6 +55,7 @@ mailto
 md
 mixin
 mixins
+ms
 multimeters
 mv
 namespace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,8 @@ exclude_lines = [
   "raise NotImplementedError"
 ]
 fail_under = 100
-# TODO: remove the exclusion of the commands
 omit = [
-  "**/tm_devices/commands/**"
+  "**/tm_devices/commands/**"  # TODO: remove this exclusion
 ]
 show_missing = true
 skip_empty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -426,6 +426,7 @@ deps =
 passenv =
     PYRIGHT_PYTHON_GLOBAL_NODE  # If set outside of tox, this will cause python-pyright to use nodeenv to install node rather than use the system node
 setenv =
+    COVERAGE_FILE = .coverage_{envname}
     DOC_PYTHON_VERSION = python3.11  # Keep this in sync with .readthedocs.yml and any CI scripts
     # Skip pre-commit checks that are not needed (yamlfix should be removed from this list once Python 3.8 support is dropped)
     SKIP = file-contents-sorter,yamlfix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,9 @@ exclude_lines = [
   "raise NotImplementedError"
 ]
 fail_under = 100
+# TODO: remove the exclusion of the commands
 omit = [
-  "**/tm_devices/commands/**"  # TODO: remove this exclusion
+  "**/tm_devices/commands/**"
 ]
 show_missing = true
 skip_empty = true

--- a/src/tm_devices/components/dm_config_parser.py
+++ b/src/tm_devices/components/dm_config_parser.py
@@ -352,7 +352,7 @@ class DMConfigParser:
         Raises:
             KeyError: Indicates unrecognized option name.
         """
-        options_list = {
+        options_dict = {
             arg.strip().split("=", maxsplit=1)[0]: bool(arg)
             if "=" not in arg
             else arg.split("=", maxsplit=1)[-1]
@@ -360,16 +360,14 @@ class DMConfigParser:
             if arg
         }
         valid_config_options = {option.upper() for option in get_type_hints(DMConfigOptions)}
-        if valid_config_options.issuperset(options_list):
+        if valid_config_options.issuperset(options_dict):
             options = {
-                arg_name.lower(): _convert_config_values(options_list[arg_name])
-                if arg_name in options_list
-                else False
-                for arg_name in valid_config_options
+                arg_name.lower(): _convert_config_values(options_dict[arg_name])
+                for arg_name in options_dict
             }
             return DMConfigOptions(**options)  # pyright: ignore[reportArgumentType]
         msg = (
-            f"Invalid configuration options found: {list(set(options_list) - valid_config_options)}"
+            f"Invalid configuration options found: {list(set(options_dict) - valid_config_options)}"
         )
         raise KeyError(msg)
 

--- a/src/tm_devices/components/dm_config_parser.py
+++ b/src/tm_devices/components/dm_config_parser.py
@@ -314,18 +314,17 @@ class DMConfigParser:
         """
         if config_file_path is None:
             config_file_path = self.defined_config_file_path
-        else:
-            config_file_path = cast(str, config_file_path)
 
-        with open(config_file_path, "w", encoding="utf-8") as config_file:
-            file_type = (
-                DMConfigParser.FileType.TOML
-                if config_file_path.lower().endswith(".toml")
-                else DMConfigParser.FileType.YAML
-            )
-            config_file.write(self.to_config_file_text(file_type=file_type))
+        config_path_obj = pathlib.Path(config_file_path)
 
-        return config_file_path
+        file_type = (
+            DMConfigParser.FileType.TOML
+            if config_path_obj.as_posix().lower().endswith(".toml")
+            else DMConfigParser.FileType.YAML
+        )
+        config_path_obj.write_text(self.to_config_file_text(file_type=file_type), encoding="utf-8")
+
+        return config_path_obj.as_posix()
 
     ################################################################################################
     # Private Methods

--- a/src/tm_devices/components/dm_config_parser.py
+++ b/src/tm_devices/components/dm_config_parser.py
@@ -362,7 +362,9 @@ class DMConfigParser:
         valid_config_options = {option.upper() for option in get_type_hints(DMConfigOptions)}
         if valid_config_options.issuperset(options_dict):
             options = {
-                arg_name.lower(): _convert_config_values(options_dict[arg_name])
+                arg_name.lower(): int(options_dict[arg_name])
+                if isinstance(options_dict[arg_name], str) and options_dict[arg_name].isdigit()  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+                else options_dict[arg_name]
                 for arg_name in options_dict
             }
             return DMConfigOptions(**options)  # pyright: ignore[reportArgumentType]
@@ -452,22 +454,3 @@ class DMConfigParser:
                 }:
                     # assign the dict to the correct key via the class the prefix represented
                     entry[self._CONFIG_NESTED_DICT_MAPPING[to_class]] = config_dict
-
-
-####################################################################################################
-# Private Functions
-####################################################################################################
-def _convert_config_values(value: Union[str, bool]) -> Union[int, str, bool]:  # pragma: no cover
-    """Convert a string into an integer if possible, otherwise leave it as its current type.
-
-    Args:
-        value: The value to convert.
-
-    Returns:
-        The converted value.
-    """
-    if isinstance(value, str):
-        if value.isdigit():
-            return int(value)
-        return value
-    return value

--- a/src/tm_devices/device_manager.py
+++ b/src/tm_devices/device_manager.py
@@ -1376,7 +1376,12 @@ class DeviceManager(metaclass=Singleton):
         try:
             model_series = get_model_series(idn_response.split(",")[1])
             device_driver = cast(Type[PIDevice], device_drivers[model_series])
-            new_device = device_driver(device_config, self.__verbose, visa_resource)
+            new_device = device_driver(
+                device_config,
+                self.__verbose,
+                visa_resource,
+                self.__config.options.default_visa_timeout,
+            )
         except (KeyError, IndexError) as error:
             visa_resource.close()
             message = "Unable to determine which device driver to use."

--- a/src/tm_devices/drivers/device.py
+++ b/src/tm_devices/drivers/device.py
@@ -262,7 +262,7 @@ class Device(ExtendableMixin, ABC):
 
         Usually something like "SCOPE 1"
         """
-        return f"{self.device_type} {self.device_number}"
+        return f"{self.device_type}" + (f" {self.device_number}" if self.device_number > 0 else "")
 
     @property
     def port(self) -> Optional[int]:

--- a/src/tm_devices/drivers/device.py
+++ b/src/tm_devices/drivers/device.py
@@ -262,7 +262,7 @@ class Device(ExtendableMixin, ABC):
 
         Usually something like "SCOPE 1"
         """
-        return f"{self.device_type}" + (f" {self.device_number}" if self.device_number > 0 else "")
+        return f"{self.device_type} {max(0, self.device_number) or ''}".strip()
 
     @property
     def port(self) -> Optional[int]:

--- a/src/tm_devices/drivers/pi/data_acquisition_systems/daq6510.py
+++ b/src/tm_devices/drivers/pi/data_acquisition_systems/daq6510.py
@@ -28,6 +28,7 @@ class DAQ6510(DAQ6510Mixin, DataAcquisitionSystem):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DAQ6510 device.
 
@@ -35,8 +36,9 @@ class DAQ6510(DAQ6510Mixin, DataAcquisitionSystem):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/digital_multimeters/dmm6500.py
+++ b/src/tm_devices/drivers/pi/digital_multimeters/dmm6500.py
@@ -25,6 +25,7 @@ class DMM6500(DMM6500Mixin, DigitalMultimeter):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DMM6500 device.
 
@@ -32,9 +33,10 @@ class DMM6500(DMM6500Mixin, DigitalMultimeter):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/digital_multimeters/dmm75xx/dmm7510.py
+++ b/src/tm_devices/drivers/pi/digital_multimeters/dmm75xx/dmm7510.py
@@ -18,6 +18,7 @@ class DMM7510(DMM7510Mixin, DMM75xx):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DMM7510 device.
 
@@ -25,9 +26,10 @@ class DMM7510(DMM7510Mixin, DMM75xx):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/digital_multimeters/dmm75xx/dmm7512.py
+++ b/src/tm_devices/drivers/pi/digital_multimeters/dmm75xx/dmm7512.py
@@ -17,6 +17,7 @@ class DMM7512(DMM75xx):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DMM7512 device.
 
@@ -24,9 +25,10 @@ class DMM7512(DMM75xx):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/digital_multimeters/dmm75xx/dmm75xx.py
+++ b/src/tm_devices/drivers/pi/digital_multimeters/dmm75xx/dmm75xx.py
@@ -25,6 +25,7 @@ class DMM75xx(DigitalMultimeter, ABC):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DMM75xx device.
 
@@ -32,9 +33,10 @@ class DMM75xx(DigitalMultimeter, ABC):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/pi_device.py
+++ b/src/tm_devices/drivers/pi/pi_device.py
@@ -32,7 +32,6 @@ from tm_devices.helpers import (
 
 # noinspection PyPep8Naming
 from tm_devices.helpers import ReadOnlyCachedProperty as cached_property  # noqa: N813
-from tm_devices.helpers.constants_and_dataclasses import UNIT_TEST_TIMEOUT
 
 
 class PIDevice(Device, ABC):  # pylint: disable=too-many-public-methods
@@ -50,6 +49,7 @@ class PIDevice(Device, ABC):  # pylint: disable=too-many-public-methods
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a PI device.
 
@@ -57,6 +57,7 @@ class PIDevice(Device, ABC):  # pylint: disable=too-many-public-methods
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         super().__init__(config_entry, verbose)
         self._visa_resource: visa.resources.MessageBasedResource = visa_resource
@@ -69,11 +70,7 @@ class PIDevice(Device, ABC):  # pylint: disable=too-many-public-methods
             # Mark this as a simulated VISA backend
             self._visa_library_path += "@sim"
         # Use a default timeout of 30 seconds, if running unit tests use a smaller amount.
-        self._default_visa_timeout = (  # TODO: use new config option
-            30000
-            if not bool(os.environ.get("TM_DEVICES_UNIT_TESTS_RUNNING"))
-            else UNIT_TEST_TIMEOUT
-        )
+        self._default_visa_timeout = default_visa_timeout
         self._ieee_cmds = self._IEEE_COMMANDS_CLASS(self)
         self.reset_visa_timeout()
 
@@ -948,7 +945,7 @@ class PIDevice(Device, ABC):  # pylint: disable=too-many-public-methods
         self.visa_timeout = (
             120000
             if not bool(os.environ.get("TM_DEVICES_UNIT_TESTS_RUNNING"))
-            else UNIT_TEST_TIMEOUT
+            else self.default_visa_timeout
         )
         self.ieee_cmds.cls()
         self.reset()

--- a/src/tm_devices/drivers/pi/pi_device.py
+++ b/src/tm_devices/drivers/pi/pi_device.py
@@ -69,7 +69,7 @@ class PIDevice(Device, ABC):  # pylint: disable=too-many-public-methods
             # Mark this as a simulated VISA backend
             self._visa_library_path += "@sim"
         # Use a default timeout of 30 seconds, if running unit tests use a smaller amount.
-        self._default_visa_timeout = (
+        self._default_visa_timeout = (  # TODO: use new config option
             30000
             if not bool(os.environ.get("TM_DEVICES_UNIT_TESTS_RUNNING"))
             else UNIT_TEST_TIMEOUT

--- a/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2220.py
+++ b/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2220.py
@@ -17,6 +17,7 @@ class PSU2220(PSU2200):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a PSU2220 device.
 
@@ -24,6 +25,7 @@ class PSU2220(PSU2200):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2230.py
+++ b/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2230.py
@@ -17,6 +17,7 @@ class PSU2230(PSU2200):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a PSU2230 device.
 
@@ -24,6 +25,7 @@ class PSU2230(PSU2200):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2231.py
+++ b/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2231.py
@@ -17,6 +17,7 @@ class PSU2231(PSU2200):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a PSU2231 device.
 
@@ -24,6 +25,7 @@ class PSU2231(PSU2200):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2231a.py
+++ b/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2231a.py
@@ -17,6 +17,7 @@ class PSU2231A(PSU2231):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a PSU2231A device.
 
@@ -24,6 +25,7 @@ class PSU2231A(PSU2231):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2280.py
+++ b/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2280.py
@@ -17,6 +17,7 @@ class PSU2280(PSU2200):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a PSU2280 device.
 
@@ -24,9 +25,10 @@ class PSU2280(PSU2200):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2281.py
+++ b/src/tm_devices/drivers/pi/power_supplies/psu2200/psu2281.py
@@ -17,6 +17,7 @@ class PSU2281(PSU2200):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a PSU2281 device.
 
@@ -24,6 +25,7 @@ class PSU2281(PSU2200):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope/lpd6.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/lpd6.py
@@ -18,6 +18,7 @@ class LPD6(LPD6Mixin, MSO6):  # pyright: ignore[reportIncompatibleMethodOverride
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO6 device.
 
@@ -25,6 +26,7 @@ class LPD6(LPD6Mixin, MSO6):  # pyright: ignore[reportIncompatibleMethodOverride
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope/mso2.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/mso2.py
@@ -23,6 +23,7 @@ class MSO2(MSO2Mixin, TekScope):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO2 device.
 
@@ -30,8 +31,9 @@ class MSO2(MSO2Mixin, TekScope):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
         # MSO2 takes 15-20 seconds for shutdown, needs more time before opening visa connection.
         self._reboot_quiet_period = 20
         # the DCH1 channel has 16 bit lanes

--- a/src/tm_devices/drivers/pi/scopes/tekscope/mso4.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/mso4.py
@@ -18,6 +18,7 @@ class MSO4(MSO4Mixin, TekScope):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO4 device.
 
@@ -25,6 +26,7 @@ class MSO4(MSO4Mixin, TekScope):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope/mso4b.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/mso4b.py
@@ -18,6 +18,7 @@ class MSO4B(MSO4BMixin, MSO4):  # pyright: ignore[reportIncompatibleMethodOverri
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO4B device.
 
@@ -25,6 +26,7 @@ class MSO4B(MSO4BMixin, MSO4):  # pyright: ignore[reportIncompatibleMethodOverri
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope/mso5.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/mso5.py
@@ -18,6 +18,7 @@ class MSO5(MSO5Mixin, TekScope):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO5 device.
 
@@ -25,6 +26,7 @@ class MSO5(MSO5Mixin, TekScope):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope/mso5b.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/mso5b.py
@@ -18,6 +18,7 @@ class MSO5B(MSO5BMixin, MSO5):  # pyright: ignore[reportIncompatibleMethodOverri
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO5B device.
 
@@ -25,9 +26,10 @@ class MSO5B(MSO5BMixin, MSO5):  # pyright: ignore[reportIncompatibleMethodOverri
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Private Methods

--- a/src/tm_devices/drivers/pi/scopes/tekscope/mso5lp.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/mso5lp.py
@@ -18,6 +18,7 @@ class MSO5LP(MSO5LPMixin, MSO5):  # pyright: ignore[reportIncompatibleMethodOver
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO5LP device.
 
@@ -25,6 +26,7 @@ class MSO5LP(MSO5LPMixin, MSO5):  # pyright: ignore[reportIncompatibleMethodOver
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope/mso6.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/mso6.py
@@ -18,6 +18,7 @@ class MSO6(MSO6Mixin, TekScope):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO6 device.
 
@@ -25,6 +26,7 @@ class MSO6(MSO6Mixin, TekScope):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope/mso6b.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/mso6b.py
@@ -18,6 +18,7 @@ class MSO6B(MSO6BMixin, MSO6):  # pyright: ignore[reportIncompatibleMethodOverri
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO6B device.
 
@@ -25,6 +26,7 @@ class MSO6B(MSO6BMixin, MSO6):  # pyright: ignore[reportIncompatibleMethodOverri
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope/tekscope.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/tekscope.py
@@ -47,7 +47,6 @@ from tm_devices.helpers import DeviceConfigEntry, LoadImpedanceAFG
 
 # noinspection PyPep8Naming
 from tm_devices.helpers import ReadOnlyCachedProperty as cached_property  # noqa: N813
-from tm_devices.helpers.constants_and_dataclasses import UNIT_TEST_TIMEOUT
 from tm_devices.helpers.enums import (
     SignalGeneratorFunctionsIAFG,
     SignalGeneratorOutputPathsBase,
@@ -106,6 +105,7 @@ class TekScope(
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a TekScope device.
 
@@ -113,8 +113,9 @@ class TekScope(
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
         self.write("HEADER OFF", verbose=False)
 
         # TODO: this should be a property of the probe attribute on the channel object
@@ -130,7 +131,9 @@ class TekScope(
         channel_map: Dict[str, TekScopeChannel] = {}
 
         with self.temporary_verbose(False) and self.temporary_visa_timeout(
-            500 if not bool(os.environ.get("TM_DEVICES_UNIT_TESTS_RUNNING")) else UNIT_TEST_TIMEOUT
+            500
+            if not bool(os.environ.get("TM_DEVICES_UNIT_TESTS_RUNNING"))
+            else self.default_visa_timeout
         ):
             # Set scope PI to be verbose
             old_pi_verbosity = self.query(":VERBose?")

--- a/src/tm_devices/drivers/pi/scopes/tekscope/tekscopesw.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope/tekscopesw.py
@@ -22,6 +22,7 @@ class TekScopePC(TekScopePCMixin, TekScope):  # pyright: ignore[reportIncompatib
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a TekScopePC device.
 
@@ -29,8 +30,9 @@ class TekScopePC(TekScopePCMixin, TekScope):  # pyright: ignore[reportIncompatib
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_2k/dpo2k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_2k/dpo2k.py
@@ -18,6 +18,7 @@ class DPO2K(DPO2KMixin, TekScope2k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO2K device.
 
@@ -25,9 +26,10 @@ class DPO2K(DPO2KMixin, TekScope2k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_2k/dpo2kb.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_2k/dpo2kb.py
@@ -18,6 +18,7 @@ class DPO2KB(DPO2KBMixin, DPO2K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO2KB device.
 
@@ -25,9 +26,10 @@ class DPO2KB(DPO2KBMixin, DPO2K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_2k/mso2k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_2k/mso2k.py
@@ -18,6 +18,7 @@ class MSO2K(MSO2KMixin, TekScope2k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO2K device.
 
@@ -25,9 +26,10 @@ class MSO2K(MSO2KMixin, TekScope2k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_2k/mso2kb.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_2k/mso2kb.py
@@ -18,6 +18,7 @@ class MSO2KB(MSO2KBMixin, MSO2K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO2KB device.
 
@@ -25,9 +26,10 @@ class MSO2KB(MSO2KBMixin, MSO2K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/dpo4k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/dpo4k.py
@@ -18,6 +18,7 @@ class DPO4K(DPO4KMixin, TekScope3k4k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO4K device.
 
@@ -25,9 +26,10 @@ class DPO4K(DPO4KMixin, TekScope3k4k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/dpo4kb.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/dpo4kb.py
@@ -18,6 +18,7 @@ class DPO4KB(DPO4KBMixin, DPO4K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO2KB device.
 
@@ -25,9 +26,10 @@ class DPO4KB(DPO4KBMixin, DPO4K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo3.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo3.py
@@ -21,6 +21,7 @@ class MDO3(MDO3Mixin, TekScope3k4k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MDO3 device.
 
@@ -28,9 +29,10 @@ class MDO3(MDO3Mixin, TekScope3k4k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo3k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo3k.py
@@ -18,6 +18,7 @@ class MDO3K(MDO3KMixin, TekScope3k4k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MDO3K device.
 
@@ -25,9 +26,10 @@ class MDO3K(MDO3KMixin, TekScope3k4k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo4k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo4k.py
@@ -18,6 +18,7 @@ class MDO4K(MDO4KMixin, TekScope3k4k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MDO4K device.
 
@@ -25,9 +26,10 @@ class MDO4K(MDO4KMixin, TekScope3k4k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo4kb.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo4kb.py
@@ -18,6 +18,7 @@ class MDO4KB(MDO4KBMixin, MDO4K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MDO4KB device.
 
@@ -25,9 +26,10 @@ class MDO4KB(MDO4KBMixin, MDO4K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo4kc.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mdo4kc.py
@@ -18,6 +18,7 @@ class MDO4KC(MDO4KCMixin, MDO4KB):  # pyright: ignore[reportIncompatibleMethodOv
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MDO4KC device.
 
@@ -25,9 +26,10 @@ class MDO4KC(MDO4KCMixin, MDO4KB):  # pyright: ignore[reportIncompatibleMethodOv
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mso4k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mso4k.py
@@ -18,6 +18,7 @@ class MSO4K(MSO4KMixin, TekScope3k4k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO4K device.
 
@@ -25,9 +26,10 @@ class MSO4K(MSO4KMixin, TekScope3k4k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mso4kb.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_3k_4k/mso4kb.py
@@ -18,6 +18,7 @@ class MSO4KB(MSO4KBMixin, MSO4K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO4KB device.
 
@@ -25,9 +26,10 @@ class MSO4KB(MSO4KBMixin, MSO4K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo5k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo5k.py
@@ -18,6 +18,7 @@ class DPO5K(DPO5KMixin, TekScope5k7k70k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO5K device.
 
@@ -25,9 +26,10 @@ class DPO5K(DPO5KMixin, TekScope5k7k70k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo5kb.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo5kb.py
@@ -18,6 +18,7 @@ class DPO5KB(DPO5KBMixin, DPO5K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO5KB device.
 
@@ -25,6 +26,7 @@ class DPO5KB(DPO5KBMixin, DPO5K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70k.py
@@ -17,6 +17,7 @@ class DPO70K(TekScope5k7k70k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO70K device.
 
@@ -24,9 +25,10 @@ class DPO70K(TekScope5k7k70k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70kc.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70kc.py
@@ -18,6 +18,7 @@ class DPO70KC(DPO70KCMixin, DPO70K):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO70KC device.
 
@@ -25,6 +26,7 @@ class DPO70KC(DPO70KCMixin, DPO70K):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70kd.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70kd.py
@@ -18,6 +18,7 @@ class DPO70KD(DPO70KDMixin, DPO70KC):  # pyright: ignore[reportIncompatibleMetho
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO70KD device.
 
@@ -25,6 +26,7 @@ class DPO70KD(DPO70KDMixin, DPO70KC):  # pyright: ignore[reportIncompatibleMetho
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70kdx.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70kdx.py
@@ -18,6 +18,7 @@ class DPO70KDX(DPO70KDXMixin, DPO70K):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO70KDX device.
 
@@ -25,6 +26,7 @@ class DPO70KDX(DPO70KDXMixin, DPO70K):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70ksx.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo70ksx.py
@@ -18,6 +18,7 @@ class DPO70KSX(DPO70KSXMixin, DPO70K):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO70KSX device.
 
@@ -25,6 +26,7 @@ class DPO70KSX(DPO70KSXMixin, DPO70K):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo7k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo7k.py
@@ -18,6 +18,7 @@ class DPO7K(DPO7KMixin, TekScope5k7k70k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO7K device.
 
@@ -25,9 +26,10 @@ class DPO7K(DPO7KMixin, TekScope5k7k70k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo7kc.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dpo7kc.py
@@ -18,6 +18,7 @@ class DPO7KC(DPO7KCMixin, DPO7K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DPO7KC device.
 
@@ -25,6 +26,7 @@ class DPO7KC(DPO7KCMixin, DPO7K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dsa70k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dsa70k.py
@@ -17,6 +17,7 @@ class DSA70K(TekScope5k7k70k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DSA70K device.
 
@@ -24,9 +25,10 @@ class DSA70K(TekScope5k7k70k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dsa70kc.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dsa70kc.py
@@ -18,6 +18,7 @@ class DSA70KC(DSA70KCMixin, DSA70K):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DSA70KC device.
 
@@ -25,6 +26,7 @@ class DSA70KC(DSA70KCMixin, DSA70K):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dsa70kd.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/dsa70kd.py
@@ -18,6 +18,7 @@ class DSA70KD(DSA70KDMixin, DSA70K):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a DSA70KD device.
 
@@ -25,6 +26,7 @@ class DSA70KD(DSA70KDMixin, DSA70K):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso5k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso5k.py
@@ -18,6 +18,7 @@ class MSO5K(MSO5KMixin, TekScope5k7k70k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO5K device.
 
@@ -25,9 +26,10 @@ class MSO5K(MSO5KMixin, TekScope5k7k70k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso5kb.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso5kb.py
@@ -18,6 +18,7 @@ class MSO5KB(MSO5KBMixin, MSO5K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO5KB device.
 
@@ -25,6 +26,7 @@ class MSO5KB(MSO5KBMixin, MSO5K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso70k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso70k.py
@@ -17,6 +17,7 @@ class MSO70K(TekScope5k7k70k):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO70K device.
 
@@ -24,9 +25,10 @@ class MSO70K(TekScope5k7k70k):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso70kc.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso70kc.py
@@ -18,6 +18,7 @@ class MSO70KC(MSO70KCMixin, MSO70K):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO70KC device.
 
@@ -25,6 +26,7 @@ class MSO70KC(MSO70KCMixin, MSO70K):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso70kdx.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/mso70kdx.py
@@ -18,6 +18,7 @@ class MSO70KDX(MSO70KDXMixin, MSO70K):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a MSO70KDX device.
 
@@ -25,6 +26,7 @@ class MSO70KDX(MSO70KDXMixin, MSO70K):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/tekscope_5k_7k_70k.py
+++ b/src/tm_devices/drivers/pi/scopes/tekscope_5k_7k_70k/tekscope_5k_7k_70k.py
@@ -24,6 +24,7 @@ class TekScope5k7k70k(Scope, ABC):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a TekScope5k7k70k device.
 
@@ -31,8 +32,9 @@ class TekScope5k7k70k(Scope, ABC):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
         self.write("HEADER OFF", verbose=False)
         # Extract the numeric part as string from the model number
         digits = "".join(char for char in self.model if char.isdigit())

--- a/src/tm_devices/drivers/pi/scopes/tso/tsovu.py
+++ b/src/tm_devices/drivers/pi/scopes/tso/tsovu.py
@@ -19,6 +19,7 @@ class TSOVu(Scope):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a TSOVu device.
 
@@ -26,8 +27,9 @@ class TSOVu(Scope):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
         self.write("HEADER OFF", verbose=False)
 
     ################################################################################################

--- a/src/tm_devices/drivers/pi/signal_generators/afgs/afg31k.py
+++ b/src/tm_devices/drivers/pi/signal_generators/afgs/afg31k.py
@@ -36,6 +36,7 @@ class AFG31K(AFG):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AFG31K device.
 
@@ -43,9 +44,10 @@ class AFG31K(AFG):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/signal_generators/afgs/afg3k.py
+++ b/src/tm_devices/drivers/pi/signal_generators/afgs/afg3k.py
@@ -34,6 +34,7 @@ class AFG3K(AFG3KMixin, AFG):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AFG3K device.
 
@@ -41,9 +42,10 @@ class AFG3K(AFG3KMixin, AFG):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Private Methods

--- a/src/tm_devices/drivers/pi/signal_generators/afgs/afg3kb.py
+++ b/src/tm_devices/drivers/pi/signal_generators/afgs/afg3kb.py
@@ -18,6 +18,7 @@ class AFG3KB(AFG3KBMixin, AFG3K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AFG3KB device.
 
@@ -25,9 +26,10 @@ class AFG3KB(AFG3KBMixin, AFG3K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Public Methods

--- a/src/tm_devices/drivers/pi/signal_generators/afgs/afg3kc.py
+++ b/src/tm_devices/drivers/pi/signal_generators/afgs/afg3kc.py
@@ -22,6 +22,7 @@ class AFG3KC(AFG3KCMixin, AFG3K):  # pyright: ignore[reportIncompatibleMethodOve
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AFG3KC device.
 
@@ -29,9 +30,10 @@ class AFG3KC(AFG3KCMixin, AFG3K):  # pyright: ignore[reportIncompatibleMethodOve
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/signal_generators/awgs/awg5200.py
+++ b/src/tm_devices/drivers/pi/signal_generators/awgs/awg5200.py
@@ -49,6 +49,7 @@ class AWG5200(AWG5200Mixin, AWG):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AWG5200 device.
 
@@ -56,9 +57,10 @@ class AWG5200(AWG5200Mixin, AWG):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/signal_generators/awgs/awg5k.py
+++ b/src/tm_devices/drivers/pi/signal_generators/awgs/awg5k.py
@@ -38,6 +38,7 @@ class AWG5K(AWG5KMixin, AWG):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AWG5K device.
 
@@ -45,9 +46,10 @@ class AWG5K(AWG5KMixin, AWG):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/signal_generators/awgs/awg5kb.py
+++ b/src/tm_devices/drivers/pi/signal_generators/awgs/awg5kb.py
@@ -17,6 +17,7 @@ class AWG5KB(AWG5K):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AWG5KB device.
 
@@ -24,6 +25,7 @@ class AWG5KB(AWG5K):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/signal_generators/awgs/awg5kc.py
+++ b/src/tm_devices/drivers/pi/signal_generators/awgs/awg5kc.py
@@ -18,6 +18,7 @@ class AWG5KC(AWG5KCMixin, AWG5KB):  # pyright: ignore[reportIncompatibleMethodOv
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AWG5KC device.
 
@@ -25,6 +26,7 @@ class AWG5KC(AWG5KCMixin, AWG5KB):  # pyright: ignore[reportIncompatibleMethodOv
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/signal_generators/awgs/awg70ka.py
+++ b/src/tm_devices/drivers/pi/signal_generators/awgs/awg70ka.py
@@ -43,6 +43,7 @@ class AWG70KA(AWG70KAMixin, AWG):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AWG70KA device.
 
@@ -50,9 +51,10 @@ class AWG70KA(AWG70KAMixin, AWG):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/signal_generators/awgs/awg70kb.py
+++ b/src/tm_devices/drivers/pi/signal_generators/awgs/awg70kb.py
@@ -18,6 +18,7 @@ class AWG70KB(AWG70KBMixin, AWG70KA):  # pyright: ignore[reportIncompatibleMetho
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AWG70KB device.
 
@@ -25,6 +26,7 @@ class AWG70KB(AWG70KBMixin, AWG70KA):  # pyright: ignore[reportIncompatibleMetho
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/signal_generators/awgs/awg7k.py
+++ b/src/tm_devices/drivers/pi/signal_generators/awgs/awg7k.py
@@ -42,6 +42,7 @@ class AWG7K(AWG7KMixin, AWG):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AWG7K device.
 
@@ -49,9 +50,10 @@ class AWG7K(AWG7KMixin, AWG):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/drivers/pi/signal_generators/awgs/awg7kb.py
+++ b/src/tm_devices/drivers/pi/signal_generators/awgs/awg7kb.py
@@ -17,6 +17,7 @@ class AWG7KB(AWG7K):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AWG7KB device.
 
@@ -24,6 +25,7 @@ class AWG7KB(AWG7K):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/signal_generators/awgs/awg7kc.py
+++ b/src/tm_devices/drivers/pi/signal_generators/awgs/awg7kc.py
@@ -18,6 +18,7 @@ class AWG7KC(AWG7KCMixin, AWG7KB):  # pyright: ignore[reportIncompatibleMethodOv
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create an AWG7KC device.
 
@@ -25,9 +26,10 @@ class AWG7KC(AWG7KCMixin, AWG7KB):  # pyright: ignore[reportIncompatibleMethodOv
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Public Methods

--- a/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2400.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2400.py
@@ -17,6 +17,7 @@ class SMU2400(SMU24xxStandard):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2400 device.
 
@@ -24,6 +25,7 @@ class SMU2400(SMU24xxStandard):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2401.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2401.py
@@ -17,6 +17,7 @@ class SMU2401(SMU24xxStandard):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2401 device.
 
@@ -24,6 +25,7 @@ class SMU2401(SMU24xxStandard):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2410.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2410.py
@@ -17,6 +17,7 @@ class SMU2410(SMU24xxStandard):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2410 device.
 
@@ -24,6 +25,7 @@ class SMU2410(SMU24xxStandard):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2450.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2450.py
@@ -20,6 +20,7 @@ class SMU2450(SMU2450Mixin, SMU24xxInteractive):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2450 device.
 
@@ -27,6 +28,7 @@ class SMU2450(SMU2450Mixin, SMU24xxInteractive):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2460.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2460.py
@@ -20,6 +20,7 @@ class SMU2460(SMU2460Mixin, SMU24xxInteractive):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2460 device.
 
@@ -27,6 +28,7 @@ class SMU2460(SMU2460Mixin, SMU24xxInteractive):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2461.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2461.py
@@ -20,6 +20,7 @@ class SMU2461(SMU2461Mixin, SMU24xxInteractive):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2461 device.
 
@@ -27,6 +28,7 @@ class SMU2461(SMU2461Mixin, SMU24xxInteractive):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2470.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu24xx/smu2470.py
@@ -20,6 +20,7 @@ class SMU2470(SMU2470Mixin, SMU24xxInteractive):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2470 device.
 
@@ -27,6 +28,7 @@ class SMU2470(SMU2470Mixin, SMU24xxInteractive):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2601a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2601a.py
@@ -17,6 +17,7 @@ class SMU2601A(SMU26xxA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2601A device.
 
@@ -24,6 +25,7 @@ class SMU2601A(SMU26xxA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2601b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2601b.py
@@ -18,6 +18,7 @@ class SMU2601B(SMU2601BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2601B device.
 
@@ -25,6 +26,7 @@ class SMU2601B(SMU2601BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2601b_pulse.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2601b_pulse.py
@@ -18,6 +18,7 @@ class SMU2601BPulse(SMU2601BPulseMixin, SMU2601B):  # pyright: ignore[reportInco
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2601B-PULSE device.
 
@@ -25,6 +26,7 @@ class SMU2601BPulse(SMU2601BPulseMixin, SMU2601B):  # pyright: ignore[reportInco
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2602a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2602a.py
@@ -17,6 +17,7 @@ class SMU2602A(SMU26xxA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2602A device.
 
@@ -24,6 +25,7 @@ class SMU2602A(SMU26xxA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2602b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2602b.py
@@ -18,6 +18,7 @@ class SMU2602B(SMU2602BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2602B device.
 
@@ -25,6 +26,7 @@ class SMU2602B(SMU2602BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2604a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2604a.py
@@ -17,6 +17,7 @@ class SMU2604A(SMU26xxA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2604A device.
 
@@ -24,6 +25,7 @@ class SMU2604A(SMU26xxA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2604b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2604b.py
@@ -18,6 +18,7 @@ class SMU2604B(SMU2604BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2604B device.
 
@@ -25,6 +26,7 @@ class SMU2604B(SMU2604BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2606b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2606b.py
@@ -18,6 +18,7 @@ class SMU2606B(SMU2606BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2606B device.
 
@@ -25,6 +26,7 @@ class SMU2606B(SMU2606BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2611a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2611a.py
@@ -17,6 +17,7 @@ class SMU2611A(SMU26xxA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2611A device.
 
@@ -24,6 +25,7 @@ class SMU2611A(SMU26xxA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2611b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2611b.py
@@ -18,6 +18,7 @@ class SMU2611B(SMU2611BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2611B device.
 
@@ -25,6 +26,7 @@ class SMU2611B(SMU2611BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2612a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2612a.py
@@ -17,6 +17,7 @@ class SMU2612A(SMU26xxA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2612A device.
 
@@ -24,6 +25,7 @@ class SMU2612A(SMU26xxA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2612b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2612b.py
@@ -18,6 +18,7 @@ class SMU2612B(SMU2612BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2612B device.
 
@@ -25,6 +26,7 @@ class SMU2612B(SMU2612BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2614a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2614a.py
@@ -17,6 +17,7 @@ class SMU2614A(SMU26xxA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2614A device.
 
@@ -24,6 +25,7 @@ class SMU2614A(SMU26xxA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2614b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2614b.py
@@ -18,6 +18,7 @@ class SMU2614B(SMU2614BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2614B device.
 
@@ -25,6 +26,7 @@ class SMU2614B(SMU2614BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2634a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2634a.py
@@ -17,6 +17,7 @@ class SMU2634A(SMU26xxA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2634A device.
 
@@ -24,6 +25,7 @@ class SMU2634A(SMU26xxA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2634b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2634b.py
@@ -18,6 +18,7 @@ class SMU2634B(SMU2634BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2634B device.
 
@@ -25,6 +26,7 @@ class SMU2634B(SMU2634BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2635a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2635a.py
@@ -17,6 +17,7 @@ class SMU2635A(SMU26xxA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2635A device.
 
@@ -24,6 +25,7 @@ class SMU2635A(SMU26xxA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2635b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2635b.py
@@ -18,6 +18,7 @@ class SMU2635B(SMU2635BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2635B device.
 
@@ -25,6 +26,7 @@ class SMU2635B(SMU2635BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2636a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2636a.py
@@ -17,6 +17,7 @@ class SMU2636A(SMU26xxA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2636A device.
 
@@ -24,6 +25,7 @@ class SMU2636A(SMU26xxA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2636b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2636b.py
@@ -18,6 +18,7 @@ class SMU2636B(SMU2636BMixin, SMU26xxB):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2636B device.
 
@@ -25,6 +26,7 @@ class SMU2636B(SMU2636BMixin, SMU26xxB):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2651a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2651a.py
@@ -18,6 +18,7 @@ class SMU2651A(SMU2651AMixin, SMU265xA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2651A device.
 
@@ -25,6 +26,7 @@ class SMU2651A(SMU2651AMixin, SMU265xA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2657a.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu26xx/smu2657a.py
@@ -18,6 +18,7 @@ class SMU2657A(SMU2657AMixin, SMU265xA):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU2657A device.
 
@@ -25,6 +26,7 @@ class SMU2657A(SMU2657AMixin, SMU265xA):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu60xx/smu6430.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu60xx/smu6430.py
@@ -17,6 +17,7 @@ class SMU6430(SMU6xxx):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU6430 device.
 
@@ -24,6 +25,7 @@ class SMU6430(SMU6xxx):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu60xx/smu6514.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu60xx/smu6514.py
@@ -17,6 +17,7 @@ class SMU6514(SMU6xxx):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU6514 device.
 
@@ -24,6 +25,7 @@ class SMU6514(SMU6xxx):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/source_measure_units/smu60xx/smu6517b.py
+++ b/src/tm_devices/drivers/pi/source_measure_units/smu60xx/smu6517b.py
@@ -17,6 +17,7 @@ class SMU6517B(SMU6xxx):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SMU6517B device.
 
@@ -24,6 +25,7 @@ class SMU6517B(SMU6xxx):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)

--- a/src/tm_devices/drivers/pi/systems_switches/ss3706a.py
+++ b/src/tm_devices/drivers/pi/systems_switches/ss3706a.py
@@ -25,6 +25,7 @@ class SS3706A(SS3706AMixin, SystemsSwitch):
         config_entry: DeviceConfigEntry,
         verbose: bool,
         visa_resource: visa.resources.MessageBasedResource,
+        default_visa_timeout: int,
     ) -> None:
         """Create a SS3706A device.
 
@@ -32,9 +33,10 @@ class SS3706A(SS3706AMixin, SystemsSwitch):
             config_entry: A config entry object parsed by the DMConfigParser.
             verbose: A boolean indicating if verbose output should be printed.
             visa_resource: The VISA resource object.
+            default_visa_timeout: The default VISA timeout value in milliseconds.
         """
         # NOTE: This method must be defined for the documentation to properly generate
-        super().__init__(config_entry, verbose, visa_resource)
+        super().__init__(config_entry, verbose, visa_resource, default_visa_timeout)
 
     ################################################################################################
     # Properties

--- a/src/tm_devices/helpers/constants_and_dataclasses.py
+++ b/src/tm_devices/helpers/constants_and_dataclasses.py
@@ -438,6 +438,11 @@ class DMConfigOptions(AsDictionaryMixin):
     """A verbosity flag to enable extremely verbose VISA logging to stdout."""
     retry_visa_connection: Optional[bool] = None
     """A flag to enable retrying the first VISA connection attempt."""
+    default_visa_timeout: int = 5000
+    """A default VISA timeout value (in milliseconds) to use when creating VISA connections.
+
+    When this option is not set, a default value of 5000 milliseconds (5 seconds) is used.
+    """
     check_for_updates: Optional[bool] = None
     """A flag indicating if a check for updates for the package should be performed on creation of the DeviceManager."""  # noqa: E501
 
@@ -445,7 +450,7 @@ class DMConfigOptions(AsDictionaryMixin):
         """Complete config entry line for an environment variable."""
         return ",".join(
             [
-                opt_key.upper()
+                opt_key.upper() + (f"={opt_val}" if not isinstance(opt_val, bool) else "")
                 for opt_key, opt_val in self.to_dict(ignore_none=True).items()
                 if opt_val
             ]
@@ -502,7 +507,7 @@ VISA_RESOURCE_EXPRESSION_REGEX: "Final[re.Pattern[str]]" = re.compile(  # pylint
 )
 """A regex pattern used to capture pieces of VISA resource expressions."""
 
-UNIT_TEST_TIMEOUT: Final[int] = 50
+UNIT_TEST_TIMEOUT: Final[int] = 50  # TODO: remove
 """The VISA timeout value to use during unit tests, in milliseconds."""
 
 VALID_DEVICE_CONNECTION_TYPES: Final[Mapping[DeviceTypes, Tuple[ConnectionTypes, ...]]] = (

--- a/src/tm_devices/helpers/constants_and_dataclasses.py
+++ b/src/tm_devices/helpers/constants_and_dataclasses.py
@@ -507,9 +507,6 @@ VISA_RESOURCE_EXPRESSION_REGEX: "Final[re.Pattern[str]]" = re.compile(  # pylint
 )
 """A regex pattern used to capture pieces of VISA resource expressions."""
 
-UNIT_TEST_TIMEOUT: Final[int] = 50  # TODO: remove
-"""The VISA timeout value to use during unit tests, in milliseconds."""
-
 VALID_DEVICE_CONNECTION_TYPES: Final[Mapping[DeviceTypes, Tuple[ConnectionTypes, ...]]] = (
     MappingProxyType(
         {

--- a/tests/samples/sample_devices.toml
+++ b/tests/samples/sample_devices.toml
@@ -28,6 +28,7 @@ baud_rate = 9600
 end_input = "none"
 
 [options]
+default_visa_timeout = 1000
 setup_cleanup = false
 standalone = true
 teardown_cleanup = false

--- a/tests/samples/sample_devices.yaml
+++ b/tests/samples/sample_devices.yaml
@@ -21,6 +21,7 @@ devices:
       baud_rate: 9600
       end_input: none
 options:
+  default_visa_timeout: 1000
   setup_cleanup: false
   standalone: true
   teardown_cleanup: false

--- a/tests/test_afgs.py
+++ b/tests/test_afgs.py
@@ -8,6 +8,7 @@ import pyvisa as visa
 
 from packaging.version import Version
 
+from conftest import UNIT_TEST_TIMEOUT
 from tm_devices import DeviceManager
 from tm_devices.drivers.pi.signal_generators.afgs.afg import (
     AFGSourceDeviceConstants,
@@ -15,7 +16,6 @@ from tm_devices.drivers.pi.signal_generators.afgs.afg import (
     ParameterBounds,
     SignalGeneratorFunctionsAFG,
 )
-from tm_devices.helpers.constants_and_dataclasses import UNIT_TEST_TIMEOUT
 
 
 def test_afg3k(device_manager: DeviceManager) -> None:  # noqa: PLR0915  # pylint: disable=too-many-locals

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -32,7 +32,7 @@ def test_nested_config_prefix_mapping() -> None:
 
 def test_environment_variable_config(capsys: pytest.CaptureFixture[str]) -> None:
     """Test the environment variable config method."""
-    options = ["STANDALONE"]
+    options = ["STANDALONE", "DEFAULT_VISA_TIMEOUT=10000"]
     expected_device_string = (
         "address=MSO54-123456,connection_type=TCPIP,device_type=SCOPE,lan_device_name=hislip0"
     )
@@ -54,12 +54,16 @@ def test_environment_variable_config(capsys: pytest.CaptureFixture[str]) -> None
     assert str(expected_device) == expected_device_string
     assert not config.options.teardown_cleanup
     assert config.options.standalone
+    assert config.options.default_visa_timeout == 10000
     assert (
         config.devices == expected_entry
     ), f"\nDevice dictionaries don't match:\n{expected_entry}\n{config.devices}"
 
     # test that the config string representation looks like env declaration
-    expected_entry_string = f"TM_OPTIONS=STANDALONE\nTM_DEVICES=~~~{expected_device_string}~~~"
+    expected_entry_string = (
+        f"TM_OPTIONS=DEFAULT_VISA_TIMEOUT=10000,STANDALONE\n"
+        f"TM_DEVICES=~~~{expected_device_string}~~~"
+    )
     print(config)
     assert capsys.readouterr().out.strip() == expected_entry_string
 
@@ -96,7 +100,10 @@ def test_environment_variable_config(capsys: pytest.CaptureFixture[str]) -> None
     assert (
         config.devices == expected_entry
     ), f"\nDevice dictionaries don't match:\n{expected_entry}\n{config.devices}"
-    expected_entry_string = f"TM_OPTIONS=STANDALONE\nTM_DEVICES=~~~{expected_device_string}~~~"
+    expected_entry_string = (
+        f"TM_OPTIONS=DEFAULT_VISA_TIMEOUT=10000,STANDALONE\n"
+        f"TM_DEVICES=~~~{expected_device_string}~~~"
+    )
     print(config)
     assert capsys.readouterr().out.strip() == expected_entry_string
 
@@ -141,6 +148,7 @@ options:
   standalone: false
   verbose_mode: false
   verbose_visa: false
+  default_visa_timeout: 10000
   """
     expected_options = DMConfigOptions(
         standalone=False,
@@ -148,6 +156,7 @@ options:
         teardown_cleanup=True,
         verbose_mode=False,
         verbose_visa=False,
+        default_visa_timeout=10000,
     )
     expected_devices = {
         "SCOPE 1": DeviceConfigEntry(
@@ -204,6 +213,7 @@ def test_file_config_non_default_path(
         teardown_cleanup=False,
         verbose_mode=False,
         verbose_visa=False,
+        default_visa_timeout=1000,
     )
     expected_devices = {
         "SCOPE 1": DeviceConfigEntry(

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -11,7 +11,7 @@ import pytest
 import pyvisa as visa
 import pyvisa.constants
 
-from conftest import SIMULATED_VISA_LIB
+from conftest import SIMULATED_VISA_LIB, UNIT_TEST_TIMEOUT
 from tm_devices import DeviceManager
 from tm_devices.helpers import ConnectionTypes, DeviceTypes, PYVISA_PY_BACKEND, SerialConfig
 
@@ -73,7 +73,7 @@ class TestDeviceManager:  # pylint: disable=no-self-use
                 text = temp_config.read()
             assert (
                 text
-                == """[[devices]]
+                == f"""[[devices]]
 address = "1"
 alias = "TESTING"
 connection_type = "SERIAL"
@@ -93,7 +93,7 @@ connection_type = "TCPIP"
 device_type = "SCOPE"
 
 [options]
-default_visa_timeout = 5000
+default_visa_timeout = {UNIT_TEST_TIMEOUT}
 setup_cleanup = false
 standalone = false
 teardown_cleanup = false
@@ -106,7 +106,7 @@ verbose_visa = false
                 print(text)
             assert (
                 text
-                == """---
+                == f"""---
 devices:
   - address: '1'
     alias: TESTING
@@ -123,7 +123,7 @@ devices:
     connection_type: TCPIP
     device_type: SCOPE
 options:
-  default_visa_timeout: 5000
+  default_visa_timeout: {UNIT_TEST_TIMEOUT}
   setup_cleanup: false
   standalone: false
   teardown_cleanup: false
@@ -137,7 +137,7 @@ options:
 
         assert (
             device_manager.get_current_configuration_as_environment_variable_strings()
-            == "TM_OPTIONS=DEFAULT_VISA_TIMEOUT=5000,VERBOSE_MODE\n"
+            == f"TM_OPTIONS=DEFAULT_VISA_TIMEOUT={UNIT_TEST_TIMEOUT},VERBOSE_MODE\n"
             "TM_DEVICES=~~~address=1,alias=TESTING,connection_type=SERIAL,device_type=SMU,"
             "serial_baud_rate=115200,serial_data_bits=8,serial_end_input=none,"
             "serial_flow_control=xon_xoff,serial_parity=none,serial_stop_bits=one"

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -93,6 +93,7 @@ connection_type = "TCPIP"
 device_type = "SCOPE"
 
 [options]
+default_visa_timeout = 5000
 setup_cleanup = false
 standalone = false
 teardown_cleanup = false
@@ -122,6 +123,7 @@ devices:
     connection_type: TCPIP
     device_type: SCOPE
 options:
+  default_visa_timeout: 5000
   setup_cleanup: false
   standalone: false
   teardown_cleanup: false
@@ -135,7 +137,7 @@ options:
 
         assert (
             device_manager.get_current_configuration_as_environment_variable_strings()
-            == "TM_OPTIONS=VERBOSE_MODE\n"
+            == "TM_OPTIONS=DEFAULT_VISA_TIMEOUT=5000,VERBOSE_MODE\n"
             "TM_DEVICES=~~~address=1,alias=TESTING,connection_type=SERIAL,device_type=SMU,"
             "serial_baud_rate=115200,serial_data_bits=8,serial_end_input=none,"
             "serial_flow_control=xon_xoff,serial_parity=none,serial_stop_bits=one"

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -40,7 +40,7 @@ def fixture_docs_server(site_dir: str) -> Generator[str, None, None]:
 def fixture_site_dir(pytestconfig: pytest.Config) -> str:
     """Create the site directory path for testing."""
     site_path = (
-        Path(__file__).parent / f".site_{sys.version_info.major}{sys.version_info.minor}/"
+        Path(__file__).parent.parent / f".site_{sys.version_info.major}{sys.version_info.minor}/"
     ).resolve()
     if xml_path := pytestconfig.getoption("xmlpath"):
         site_path = (Path(xml_path).parent / ".site_html/").resolve()  # pyright: ignore[reportArgumentType]

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -520,6 +520,7 @@ def test_tekscope2k(device_manager: DeviceManager, tmp_path: pathlib.Path) -> No
     with pytest.raises(AssertionError):
         scope.curve_query(5, wfm_type="FreqDomain")
 
-    assert scope.curve_query(5, wfm_type="TimeDomain") == []
+    with pytest.warns(UserWarning, match="source not available for curve query: CH5"):
+        assert scope.curve_query(5, wfm_type="TimeDomain") == []
 
     assert scope.curve_query(0, wfm_type="Digital") == [1, 0, 1, 0, 1]

--- a/tests/test_smu.py
+++ b/tests/test_smu.py
@@ -14,8 +14,8 @@ import pyvisa as visa
 
 from packaging.version import Version
 
+from conftest import UNIT_TEST_TIMEOUT
 from tm_devices import DeviceManager
-from tm_devices.helpers.constants_and_dataclasses import UNIT_TEST_TIMEOUT
 
 if TYPE_CHECKING:
     from tm_devices.drivers import SMU2460, SMU2601B


### PR DESCRIPTION
## Proposed changes

This enables customizing the default VISA timeout via the configuration file or environment variable.

Addresses #294 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)
- [x] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
