### PR TITLE
fix: Ensure that the default VISA timeout value is not overwritten if a new config is loaded that doesn't specify a default VISA timeout

### DIFF
--- a/src/tm_devices/device_manager.py
+++ b/src/tm_devices/device_manager.py
@@ -138,6 +138,7 @@ class DeviceManager(metaclass=Singleton):
         self.__teardown_cleanup_enabled: bool = NotImplemented
         self.__setup_cleanup_enabled: bool = NotImplemented
         self.__visa_library: str = NotImplemented
+        self.__default_visa_timeout: int = NotImplemented
 
         # Create the config
         self.__config = DMConfigParser()
@@ -180,6 +181,17 @@ class DeviceManager(metaclass=Singleton):
     ################################################################################################
     # Properties
     ################################################################################################
+    @property
+    def default_visa_timeout(self) -> int:
+        """Return the default VISA timeout value."""
+        return self.__default_visa_timeout
+
+    @default_visa_timeout.setter
+    def default_visa_timeout(self, value: int) -> None:
+        """Set the default VISA timeout value."""
+        self.__config.options.default_visa_timeout = value
+        self.__default_visa_timeout = value
+
     @property
     def devices(self) -> Mapping[str, Union[RESTAPIDevice, PIDevice]]:
         """Return the dictionary of devices."""
@@ -1380,7 +1392,7 @@ class DeviceManager(metaclass=Singleton):
                 device_config,
                 self.__verbose,
                 visa_resource,
-                self.__config.options.default_visa_timeout,
+                self.__default_visa_timeout,
             )
         except (KeyError, IndexError) as error:
             visa_resource.close()
@@ -1403,6 +1415,11 @@ class DeviceManager(metaclass=Singleton):
         )
         self.__teardown_cleanup_enabled = bool(self.__config.options.teardown_cleanup)
         self.__setup_cleanup_enabled = bool(self.__config.options.setup_cleanup)
+        self.__default_visa_timeout = (
+            5000
+            if self.__config.options.default_visa_timeout is None
+            else self.__config.options.default_visa_timeout
+        )
         # Configure the VISA library
         if self.__config.options.standalone:
             self.__visa_library = PYVISA_PY_BACKEND

--- a/src/tm_devices/helpers/constants_and_dataclasses.py
+++ b/src/tm_devices/helpers/constants_and_dataclasses.py
@@ -438,7 +438,7 @@ class DMConfigOptions(AsDictionaryMixin):
     """A verbosity flag to enable extremely verbose VISA logging to stdout."""
     retry_visa_connection: Optional[bool] = None
     """A flag to enable retrying the first VISA connection attempt."""
-    default_visa_timeout: int = 5000
+    default_visa_timeout: Optional[int] = None
     """A default VISA timeout value (in milliseconds) to use when creating VISA connections.
 
     When this option is not set, a default value of 5000 milliseconds (5 seconds) is used.

--- a/tests/samples/simulated_config.yaml
+++ b/tests/samples/simulated_config.yaml
@@ -8,3 +8,4 @@ devices:
 options:
   setup_cleanup: true
   teardown_cleanup: true
+  default_visa_timeout: 1000

--- a/tests/test_generate_waveform.py
+++ b/tests/test_generate_waveform.py
@@ -145,8 +145,8 @@ def test_awg7k_gen_waveform(device_manager: DeviceManager) -> None:
     awg7k06 = cast(AWG7K, device_manager.add_awg("awg7102opt06-hostname", alias="awg7k06"))
 
     error_match = (
-        "The offset can only be set on AWG7102 without an 02 or 06 option and with an output "
-        "signal path of DCA \(AWGCONTROL:DOUTPUT1:STATE set to 0\)."  # noqa: W605  # pylint: disable=anomalous-backslash-in-string  # pyright: ignore [reportInvalidStringEscapeSequence]
+        r"The offset can only be set on AWG7102 without an 02 or 06 option and with an output "
+        r"signal path of DCA \(AWGCONTROL:DOUTPUT1:STATE set to 0\)."
     )
     with pytest.raises(ValueError, match=error_match):
         awg7k06.source_channel["SOURCE1"].set_offset(0.2)
@@ -176,8 +176,8 @@ def test_awg7k_gen_waveform(device_manager: DeviceManager) -> None:
 
     # AWG7k with option 1 should not be able to set offset with DIR output signal path.
     error_match = (
-        "The offset can only be set on AWG7051 without an 02 or 06 option and with an output "
-        "signal path of DCA \(AWGCONTROL:DOUTPUT1:STATE set to 0\)."  # noqa: W605  # pylint: disable=anomalous-backslash-in-string  # pyright: ignore [reportInvalidStringEscapeSequence]
+        r"The offset can only be set on AWG7051 without an 02 or 06 option and with an output "
+        r"signal path of DCA \(AWGCONTROL:DOUTPUT1:STATE set to 0\)."
     )
     with pytest.raises(ValueError, match=error_match):
         awg7k01.generate_function(
@@ -251,8 +251,8 @@ def test_awg5k_gen_waveform(device_manager: DeviceManager) -> None:
 
     # Cannot set offset with DIR output signal path.
     offset_error = (
-        "The offset can only be set on AWG5012 with an output signal path of DCA "
-        "\(AWGCONTROL:DOUTPUT1:STATE set to 0\)."  # noqa: W605  # pylint: disable=anomalous-backslash-in-string  # pyright: ignore [reportInvalidStringEscapeSequence]
+        r"The offset can only be set on AWG5012 with an output signal path of DCA "
+        r"\(AWGCONTROL:DOUTPUT1:STATE set to 0\)."
     )
     with pytest.raises(ValueError, match=offset_error):
         awg5k.generate_function(


### PR DESCRIPTION
## Proposed changes

fix: Ensure that the default VISA timeout value is not overwritten if a new config is loaded that doesn't specify a default VISA timeout.

Previously, the implicit default of 5000ms would overwrite any custom timeout values, now leaving the config option unset will leave the current setting alone.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
