### PR TITLE
fix: allow empty returns from tsp_device.get_buffers()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,6 @@ However, please read through all changes to be aware of what may potentially imp
 
 - `collectgarbage()` is now called during cleanup of `TSPControl` children.
 - Added USBTMC Support for the AFG31K and MDO3 drivers.
--
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ However, please read through all changes to be aware of what may potentially imp
     - A configuration function provides the ability to set different logging levels for stdout and file logging.
     - The config file and environment variable can also be used to control the logging functionality.
     - The debug logging from the `pyvisa` package is also included in the log file by default.
+- Updated `get_buffers()` in `TSPControl` to not error out if query returns with empty string.
 
 ### Removed
 
@@ -97,6 +98,7 @@ However, please read through all changes to be aware of what may potentially imp
 
 - `collectgarbage()` is now called during cleanup of `TSPControl` children.
 - Added USBTMC Support for the AFG31K and MDO3 drivers.
+-
 
 ---
 

--- a/src/tm_devices/driver_mixins/device_control/tsp_control.py
+++ b/src/tm_devices/driver_mixins/device_control/tsp_control.py
@@ -116,7 +116,9 @@ class TSPControl(PIControl, ABC):
                 if buffer_name.endswith(attr_name):
                     buffer_size_name = buffer_name.rstrip(attr_name)
                     break
-            buffer_str = self.query(f"printbuffer(1, {buffer_size_name}.n, {buffer_name})")
+            buffer_str = self.query(
+                f"printbuffer(1, {buffer_size_name}.n, {buffer_name})", allow_empty=True
+            )
             buffer_data[buffer_name] = [float(x) for x in buffer_str.split(", ") if buffer_str]
         return buffer_data
 


### PR DESCRIPTION
## Proposed changes

Made it so the get_buffers() function does not error out if the buffers are empty.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [ ] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
