### PR TITLE
fix: updated get_buffers() with logic to handle empty buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ However, please read through all changes to be aware of what may potentially imp
     - A configuration function provides the ability to set different logging levels for stdout and file logging.
     - The config file and environment variable can also be used to control the logging functionality.
     - The debug logging from the `pyvisa` package is also included in the log file by default.
-- Updated `get_buffers()` in `TSPControl` to not error out if query returns with empty string.
+- Updated `get_buffers()` in `TSPControl` to not error out if the buffer is found to be empty.
 
 ### Removed
 

--- a/src/tm_devices/driver_mixins/device_control/tsp_control.py
+++ b/src/tm_devices/driver_mixins/device_control/tsp_control.py
@@ -116,10 +116,16 @@ class TSPControl(PIControl, ABC):
                 if buffer_name.endswith(attr_name):
                     buffer_size_name = buffer_name.rstrip(attr_name)
                     break
+            empty_str = f"{buffer_size_name} was found to be empty"
             buffer_str = self.query(
-                f"printbuffer(1, {buffer_size_name}.n, {buffer_name})", allow_empty=True
+                f"if {buffer_size_name}.n == 0 then "
+                f"print({empty_str!r}) else printbuffer(1, {buffer_size_name}.n, {buffer_name}) end"
             )
-            buffer_data[buffer_name] = [float(x) for x in buffer_str.split(", ") if buffer_str]
+            if buffer_str == empty_str:
+                _logger.warning(empty_str)
+                buffer_data[buffer_name] = []
+            else:
+                buffer_data[buffer_name] = [float(data) for data in buffer_str.split(", ") if data]
         return buffer_data
 
     def load_script(

--- a/tests/sim_devices/smu/smu2601b.yaml
+++ b/tests/sim_devices/smu/smu2601b.yaml
@@ -35,10 +35,15 @@ devices:
         r: 1
       - q: if loadfuncs ~= nil then script.delete('loadfuncs') end
       - q: if tsp_function ~= nil then script.delete('tsp_function') end
-      - q: printbuffer(1, smua.nvbuffer1.n, smua.nvbuffer1)
+      - q: if smua.nvbuffer1.n == 0 then print('smua.nvbuffer1 was found to be empty')
+          else printbuffer(1, smua.nvbuffer1.n, smua.nvbuffer1) end
         r: 1, 2, 3, 4, 5
-      - q: printbuffer(1, smua.nvbuffer1.n, smua.nvbuffer1.timestamps)
-        r: 2, 4, 6, 8, 10
+      - q: if smua.nvbuffer1.n == 0 then print('smua.nvbuffer1 was found to be empty')
+          else printbuffer(1, smua.nvbuffer1.n, smua.nvbuffer1.timestamps) end
+        r: 0.0, 0.1, 0.2, 0.3, 0.4
+      - q: if smub.nvbuffer1.n == 0 then print('smub.nvbuffer1 was found to be empty')
+          else printbuffer(1, smub.nvbuffer1.n, smub.nvbuffer1) end
+        r: smub.nvbuffer1 was found to be empty
     error:
       status_register:
         - q: print(status.standard.event)

--- a/tests/test_smu.py
+++ b/tests/test_smu.py
@@ -18,6 +18,8 @@ from conftest import UNIT_TEST_TIMEOUT
 from tm_devices import DeviceManager
 
 if TYPE_CHECKING:
+    from typing import Dict, List
+
     from tm_devices.drivers import SMU2401, SMU2460, SMU2601B, SMU6430
 
 
@@ -218,12 +220,18 @@ def test_smu(  # noqa: PLR0915
         )
         assert caplog.records[-1].levelname == "WARNING"
 
+    buffer = smu.get_buffers("smub.nvbuffer1")
+    expected_buffer: Dict[str, List[float]] = {"smub.nvbuffer1": []}
+    assert caplog.records[-1].message == "smub.nvbuffer1 was found to be empty"
+    assert caplog.records[-1].levelname == "WARNING"
+    assert buffer == expected_buffer
+
     buffer = smu.get_buffers("smua.nvbuffer1")
     expected_buffer = {"smua.nvbuffer1": [1.0, 2.0, 3.0, 4.0, 5.0]}
     assert buffer == expected_buffer
 
     buffer = smu.get_buffers("smua.nvbuffer1.timestamps")
-    expected_buffer = {"smua.nvbuffer1.timestamps": [2.0, 4.0, 6.0, 8.0, 10.0]}
+    expected_buffer = {"smua.nvbuffer1.timestamps": [0.0, 0.1, 0.2, 0.3, 0.4]}
     assert buffer == expected_buffer
 
     smu.print_buffers("smua.nvbuffer1")


### PR DESCRIPTION
## Proposed changes

updated get_buffers() with logic to handle empty buffer.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [ ] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
