### PR TITLE
refactor: Update all error messages for VISA devices to always include the failed command unless explicitly called with the method's `verbose` parameter set to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Valid subsections within a version are:
 
 Things to be included in the next release go here.
 
+### Changed
+
+- The error messages for exceptions raised during VISA communication have been updated to always include the command that was being executed when the error occurred, unless the method was explicitly called with the `verbose` parameter set to False.
+
 ---
 
 ## v3.1.2 (2025-02-12)

--- a/src/tm_devices/driver_mixins/device_control/pi_control.py
+++ b/src/tm_devices/driver_mixins/device_control/pi_control.py
@@ -349,7 +349,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
             if remove_quotes:
                 response = response.replace('"', "")
         except (visa.VisaIOError, socket.error) as error:
-            pi_cmd_repr = f" for {query!r} " if self._verbose and verbose else " "
+            pi_cmd_repr = f" for {query!r} " if verbose else " "
             msg = (
                 f"The query of {self._name_and_alias}{pi_cmd_repr}"
                 f"failed with the following message: {error!r}"
@@ -365,9 +365,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
         )
 
         if not allow_empty and not response:
-            pi_cmd_repr = (
-                f" for the following query: {query!r}" if self._verbose and verbose else ""
-            )
+            pi_cmd_repr = f" for the following query: {query!r}" if verbose else ""
             msg = f"An empty string was returned from {self._name_and_alias}{pi_cmd_repr}"
             _logger.error(msg)
             raise SystemError(msg)
@@ -398,7 +396,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
         try:
             response = self._visa_resource.query_binary_values(query)  # pyright: ignore[reportUnknownMemberType]
         except (visa.VisaIOError, socket.error) as error:
-            pi_cmd_repr = f" for {query!r} " if self._verbose and verbose else " "
+            pi_cmd_repr = f" for {query!r} " if verbose else " "
             msg = (
                 f"The binary query of {self._name_and_alias}{pi_cmd_repr}"
                 f"failed with the following message: {error!r}"
@@ -414,9 +412,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
         )
 
         if not response:
-            pi_cmd_repr = (
-                f" for the following binary query: {query!r}" if self._verbose and verbose else ""
-            )
+            pi_cmd_repr = f" for the following binary query: {query!r}" if verbose else ""
             msg = f"An empty string was returned from {self._name_and_alias}{pi_cmd_repr}"
             _logger.error(msg)
             raise SystemError(msg)
@@ -533,7 +529,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
             self._visa_resource.write(query)
             response = self.read_raw()
         except (visa.VisaIOError, socket.error) as error:
-            pi_cmd_repr = f" for {query!r} " if self._verbose and verbose else " "
+            pi_cmd_repr = f" for {query!r} " if verbose else " "
             msg = (
                 f"The raw binary query of {self._name_and_alias}{pi_cmd_repr}"
                 f"failed with the following message: {error!r}"
@@ -549,11 +545,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
         )
 
         if not response.strip():
-            pi_cmd_repr = (
-                f" for the following raw binary query: {query!r}"
-                if self._verbose and verbose
-                else ""
-            )
+            pi_cmd_repr = f" for the following raw binary query: {query!r}" if verbose else ""
             msg = f"An empty string was returned from {self._name_and_alias}{pi_cmd_repr}"
             _logger.error(msg)
             raise SystemError(msg)
@@ -871,7 +863,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
         try:
             self._visa_resource.write(command)
         except (visa.VisaIOError, socket.error) as error:
-            pi_cmd_repr = f" for {command!r} " if self._verbose and verbose else " "
+            pi_cmd_repr = f" for {command!r} " if verbose else " "
             msg = (
                 f"The write to {self._name_and_alias}{pi_cmd_repr}"
                 f"failed with the following message: {error!r}"
@@ -880,7 +872,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
             raise visa.Error(msg) from error
 
         if opc and (result := self.ieee_cmds.opc()) != "1":
-            pi_cmd_repr = f" {command!r}" if self._verbose and verbose else " the command"
+            pi_cmd_repr = f" {command!r}" if verbose else " the command"
             msg = (
                 f"After issuing{pi_cmd_repr} to {self._name_and_alias}, "
                 f"OPC returned incorrect data: {result!r}"
@@ -908,7 +900,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
         try:
             self._visa_resource.write_raw(command)
         except (visa.VisaIOError, socket.error) as error:
-            pi_cmd_repr = f" for {command!r} " if self._verbose and verbose else " "
+            pi_cmd_repr = f" for {command!r} " if verbose else " "
             msg = (
                 f"The raw write to {self._name_and_alias}"
                 f"{pi_cmd_repr}failed with the following message: {error!r}"


### PR DESCRIPTION
## Proposed changes

refactor: Update all error messages for VISA devices to always include the failed command unless explicitly called with the method's `verbose` parameter set to False

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Functionality update (non-breaking change which updates or changes existing functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
