### PR TITLE
Fixed microsecond representation in log formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Valid subsections within a version are:
 
 Things to be included in the next release go here.
 
+### Changed
+
+- Modified the logging time format to use microseconds for more precise logging.
+
 ---
 
 ## v3.1.4 (2025-03-04)

--- a/src/tm_devices/helpers/logging.py
+++ b/src/tm_devices/helpers/logging.py
@@ -49,6 +49,10 @@ class _CustomFormatterWithMicroseconds(logging.Formatter):  # pragma: no cover
             s = f"{t:s}.{ct.microsecond:06d}"
         return s
 
+
+class _CustomFormatterWithPackageNameAndMicroseconds(
+    _CustomFormatterWithMicroseconds
+):  # pragma: no cover
     def format(self, record: logging.LogRecord) -> str:
         # Add the package name to the log record
         record.package_name = record.name.split(".", maxsplit=1)[0]
@@ -160,7 +164,7 @@ def configure_logging(  # pylint: disable=too-many-locals
         # Set up logger for tm_devices
         log_filepath.parent.mkdir(parents=True, exist_ok=True)
         file_handler = logging.FileHandler(log_filepath, mode="w", encoding="utf-8")
-        file_formatter = _CustomFormatterWithMicroseconds(logging_file_format_string)
+        file_formatter = _CustomFormatterWithPackageNameAndMicroseconds(logging_file_format_string)
 
         file_handler.setLevel(getattr(logging, log_file_level.value))
         file_handler.setFormatter(file_formatter)


### PR DESCRIPTION
## Proposed changes

The timestamp was improperly formatted with zero padded milliseconds, this change refactors it back to the original 6 digits of precision with microseconds.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [ ] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
