### PR TITLE
ci: Allow retries for CI testing on MacOS

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -16,5 +16,6 @@ jobs:
       operating-systems-array: '["ubuntu", "windows", "macos"]'
       python-versions-array: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'  # when updating this, make sure to update all workflows that use this strategy
       upload-to-codecov: true
+      enable-retry-os-array: '["macos"]'
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Proposed changes

Many false failures have been observed on MacOS when running pyright as a part of pre-commit. This enables retries to attempt to work around the false failures.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
