### PR TITLE
Update AWG70K driver to properly handle when the DCA output signal path is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Things to be included in the next release go here.
 
 ### Fixed
 
-- Updated the expected error message for the set_output_signal_path method in the AWG70K driver.
+- Updated the expected error message for the `set_output_signal_path()` method in the AWG70K driver.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Valid subsections within a version are:
 
 Things to be included in the next release go here.
 
+### Fixed
+
+- Updated the expected error message for the set_output_signal_path method in the AWG70K driver.
+
 ---
 
 ## v3.1.5 (2025-03-10)

--- a/src/tm_devices/drivers/awgs/awg70ka.py
+++ b/src/tm_devices/drivers/awgs/awg70ka.py
@@ -236,10 +236,10 @@ class AWG70KASourceChannel(AWGSourceChannel):
             except AssertionError:  # pragma: no cover
                 # If error, set output signal path to DIR.
                 expected_esr_message = (
-                    '-222,"Data out of range;Data Out of Range - '
-                    f'OUTPUT{self.num}:PATH DCA\r\n"\n0,"No error"'
+                    f'-222,"Data out of range;Data Out of Range - OUTPUT{self.num}:PATH DCA\r\n"',
+                    '0,"No error"',
                 )
-                self._awg.expect_esr(16, (expected_esr_message,))
+                self._awg.expect_esr(16, expected_esr_message)
                 self._awg.set_and_check(
                     f"OUTPUT{self.num}:PATH", self._awg.OutputSignalPath.DIR.value
                 )


### PR DESCRIPTION
## Proposed changes

Updated the expected error message for the set_output_signal_path method in the AWG70K driver.

Addresses #397

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
