### PR TITLE
fix: Fixed the method of determining the total number of physical channel connectors on the 70kSX scope series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Valid subsections within a version are:
 
 Things to be included in the next release go here.
 
+### Fixed
+
+- Fixed the method of determining the total number of physical channel connectors on the 70kSX scope series to properly list all physical channels, even if not all channels can be used simultaneously, as is the case on SX scopes with the Asynchronous Time Interleaving (ATI) feature.
+
 ---
 
 ## v3.1.8 (2025-03-21)

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -423,6 +423,9 @@ def test_tekscope70k(
     # Assert the total number of digital channels.
     assert scope_70k.num_dig_bits_in_ch == 16
 
+    dpo70ksx = device_manager.add_scope("DPO70KSX-HOSTNAME")
+    assert dpo70ksx.total_channels == 3
+
 
 def test_long_device_name(device_manager: DeviceManager) -> None:
     """Test a device with a long name.


### PR DESCRIPTION
## Proposed changes

Previously a flawed method of determining the total number of physical channel connections on the 70kSX scope series was used. This PR enhances the logic determine the total channel count to allow users to access all 3 channels on SX scopes which have the ATI feature (and therefore have 3 physical channel connections).

Addresses #407

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
