### PR TITLE
Set offset after impedance so that it is properly adjusted 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Valid subsections within a version are:
 
 ## Unreleased
 
-- Fixed a bug in `set_function_properties` in the drivers for the internal AFG of the TekScope that could cause the offset value to change after setting impedance and another bug that could cause the frequency value to change after setting function.
+- Fixed a bug in `set_function_properties` in the drivers for the internal AFG of the TekScope that could cause the offset value to change after setting impedance.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Valid subsections within a version are:
 
 ## Unreleased
 
+### Fixed
+
 - Fixed a bug in `set_function_properties` in the drivers for the internal AFG of the TekScope that could cause the offset value to change after setting impedance.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Valid subsections within a version are:
 
 ## Unreleased
 
-Things to be included in the next release go here.
+- Fixed a bug in `set_function_properties` in the drivers for the internal AFG of the TekScope that could cause the offset value to change after setting impedance and another bug that could cause the frequency value to change after setting function.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Valid subsections within a version are:
 
 ## Unreleased
 
+Things to be included in the next release go here.
+
 ### Fixed
 
 - Fixed a bug in `set_function_properties` in the drivers for the internal AFG of the TekScope that could cause the offset value to change after setting impedance.

--- a/src/tm_devices/drivers/scopes/tekscope/tekscope.py
+++ b/src/tm_devices/drivers/scopes/tekscope/tekscope.py
@@ -1069,10 +1069,10 @@ class InternalAFGChannel(BaseAFGSourceChannel):
         if burst_count > 0:
             self.setup_burst_waveform(burst_count)
         # Generate the waveform from the Internal AFG
+        # Frequency
+        self.set_frequency(frequency)
         # Function
         self.set_function(function)
-        # Frequency, needs to be set after function so that the frequency is properly adjusted
-        self.set_frequency(frequency)
         # Duty Cycle
         if function == SignalGeneratorFunctionsIAFG.SQUARE:
             self.set_square_duty_cycle(duty_cycle)

--- a/src/tm_devices/drivers/scopes/tekscope/tekscope.py
+++ b/src/tm_devices/drivers/scopes/tekscope/tekscope.py
@@ -1071,8 +1071,6 @@ class InternalAFGChannel(BaseAFGSourceChannel):
         # Generate the waveform from the Internal AFG
         # Frequency
         self.set_frequency(frequency)
-        # Offset
-        self.set_offset(offset)
         # Function
         self.set_function(function)
         # Duty Cycle
@@ -1085,6 +1083,8 @@ class InternalAFGChannel(BaseAFGSourceChannel):
         self.set_impedance(termination)
         # Amplitude, needs to be after termination so that the amplitude is properly adjusted
         self.set_amplitude(amplitude)
+        # Offset, needs to be after termination so that the offset is properly adjusted
+        self.set_offset(offset)
 
     def set_amplitude(self, value: float, absolute_tolerance: float = 0) -> None:
         """Set the amplitude on the internal AFG.

--- a/src/tm_devices/drivers/scopes/tekscope/tekscope.py
+++ b/src/tm_devices/drivers/scopes/tekscope/tekscope.py
@@ -1069,10 +1069,10 @@ class InternalAFGChannel(BaseAFGSourceChannel):
         if burst_count > 0:
             self.setup_burst_waveform(burst_count)
         # Generate the waveform from the Internal AFG
-        # Frequency
-        self.set_frequency(frequency)
         # Function
         self.set_function(function)
+        # Frequency, needs to be set after function so that the frequency is properly adjusted
+        self.set_frequency(frequency)
         # Duty Cycle
         if function == SignalGeneratorFunctionsIAFG.SQUARE:
             self.set_square_duty_cycle(duty_cycle)


### PR DESCRIPTION
## Proposed changes

For the internal AFG of the TekScope, set offset after impedance so that it is properly adjusted.

Addresses #409

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
