### PR TITLE
fix: Ensure VISA timeout is reset after reboot in pi_control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Things to be included in the next release go here.
 ### Fixed
 
 - Fixed a bug in the auto-generated commands for certain models where the `limit[Y]` commands were incorrectly generated.
+- Ensure the VISA timeout is reset after a VISA device is rebooted.
 
 ---
 

--- a/src/tm_devices/driver_mixins/device_control/pi_control.py
+++ b/src/tm_devices/driver_mixins/device_control/pi_control.py
@@ -1033,5 +1033,7 @@ class PIControl(_AbstractDeviceVISAWriteQueryControl, _ExtendableMixin, ABC):  #
                     # raised by the create_visa_connection() function
                     pass
 
+        if self._visa_resource is not None:  # pyright: ignore[reportUnnecessaryComparison]
+            self.reset_visa_timeout()
         self._is_open = opened
         return opened

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -16,6 +16,7 @@ import pyvisa as visa
 from dateutil.tz import tzlocal
 from packaging.version import Version
 
+from conftest import UNIT_TEST_TIMEOUT
 from tm_devices import DeviceManager, register_additional_usbtmc_mapping
 from tm_devices.drivers import MSO2, MSO2KB, MSO5, MSO5B, MSO6, MSO70KDX, TekScopePC, TSOVu
 from tm_devices.drivers.scopes.tekscope.tekscope import (
@@ -210,8 +211,11 @@ def test_tekscope(device_manager: DeviceManager) -> None:  # noqa: PLR0915
     # Test that single sequence can be set
     scope.single_sequence()
 
-    # simulate a reboot
+    # simulate a reboot and verify the visa timeout has been reset to the default value
+    scope.visa_timeout = 1000
+    assert scope.visa_timeout == 1000
     scope.reboot()
+    assert scope.visa_timeout == UNIT_TEST_TIMEOUT
 
     # test some internal assertions
     with pytest.raises(AssertionError, match="none is not a valid item.*"):


### PR DESCRIPTION
## Proposed changes

fix: Ensure VISA timeout is reset after reboot in pi_control and update related tests
Addresses #420

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
