### PR TITLE
ci: update Python version requirement and pre-commit hook skip list in a github workflow

### DIFF
--- a/.github/workflows/update-python-and-pre-commit-dependencies.yml
+++ b/.github/workflows/update-python-and-pre-commit-dependencies.yml
@@ -13,7 +13,7 @@ jobs:
       dependency-dict: '{"tests": ["ruff"]}'
       update-pre-commit: true
       run-pre-commit: true
-      pre-commit-hook-skip-list: pylint,pyright,pyright-verifytypes,pyroma,poetry-audit
+      pre-commit-hook-skip-list: pylint,pyright,pyright-verifytypes,pyroma,poetry-lock,poetry-audit,poetry-check
       pre-commit-repo-update-skip-list: ''
       export-dependency-groups: docs,tests
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ libusb-package = "^1.0.26.0,!=1.0.26.2"  # 1.0.26.2 doesn't work with Python 3.1
 packaging = ">=24.0"
 psutil = ">=6.0.0"
 pyserial = "^3.5"
-python = "^3.9.2"  # This is the main Python version requirement
+python = ">=3.9.2,<3.14"  # This is the main Python version requirement
 python-dateutil = "^2.8.2"
 pyusb = "^1.2.1"
 pyvicp = "^1.1.0"


### PR DESCRIPTION
## Proposed changes

ci: update Python version requirement and pre-commit hook skip list in a github workflow

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [ ] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
