### PR TITLE
fix: Attempt to grab the ip_address for all connection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Things to be included in the next release go here.
 
 - Updated the `DeviceManager` to gracefully exit if the close method is not called in any scripts.
 - Updated the `DeviceManager.open()` method to behave in a more expected way (ensures existing Python objects get properly re-opened and pointers to objects don't get lost, replaced, or become stale) when called after previously closing the `DeviceManager`.
+- Updated the `Device.ip_address` property to remove the USB connection type exclusion.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,12 @@ Things to be included in the next release go here.
 ### Changed
 
 - Updated the `PIControl.query_binary()` method to include PyVISA-compatible arguments, enabling users to fully utilize the complete functionality of the PyVISA method.
+- Updated the `Device.ip_address` property to remove the USB connection type exclusion.
 
 ### Fixed
 
 - Updated the `DeviceManager` to gracefully exit if the close method is not called in any scripts.
 - Updated the `DeviceManager.open()` method to behave in a more expected way (ensures existing Python objects get properly re-opened and pointers to objects don't get lost, replaced, or become stale) when called after previously closing the `DeviceManager`.
-- Updated the `Device.ip_address` property to remove the USB connection type exclusion.
 
 ### Removed
 

--- a/src/tm_devices/drivers/device.py
+++ b/src/tm_devices/drivers/device.py
@@ -255,11 +255,10 @@ class Device(_AbstractDeviceControl, _ExtendableMixin, ABC):
     @cached_property
     def ip_address(self) -> str:
         """Return the IPv4 address of the device or an empty string if unable to fetch that."""
-        if self._config_entry.connection_type not in {ConnectionTypes.USB}:
-            try:
-                return socket.gethostbyname(self.address)
-            except (socket.gaierror, socket.herror):
-                pass
+        try:
+            return socket.gethostbyname(self.address)
+        except (socket.gaierror, socket.herror):
+            pass
         return ""
 
     ################################################################################################


### PR DESCRIPTION
## Proposed changes

Updated the `Device.ip_address` property to remove the USB connection type exclusion.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
