### PR TITLE
chore(pre-commit): pin Python version for docformatter pre-commit hook to 3.13 so that it can run in all tox environments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,9 +156,9 @@ repos:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-# TODO: uncomment when https://github.com/PyCQA/docformatter/issues/327 is resolved
-#  - repo: https://github.com/PyCQA/docformatter
-#    rev: e73b8ba0c1316be565983236c72e653ad44e6b66  # frozen: v1.7.7
-#    hooks:
-#      - id: docformatter
-#        additional_dependencies: [tomli]
+  - repo: https://github.com/PyCQA/docformatter
+    rev: e73b8ba0c1316be565983236c72e653ad44e6b66  # frozen: v1.7.7
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        language_version: python3.13  # TODO: remove this line when https://github.com/PyCQA/docformatter/issues/327 is resolved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ version = "3.5.0"
 
 [tool.poetry.group.dev.dependencies]
 nodeenv = "^1.9.1"
-pip = "^25.0"
+pip = "^26.0"
 poetry = "^2.2.0"
 poetry-audit-plugin = "^1.0.0"
 poetry-plugin-export = "^1.7.1"


### PR DESCRIPTION
## Proposed changes

chore(pre-commit): pin Python version for docformatter pre-commit hook to 3.13 so that it can run in all tox environments

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [ ] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
