### PR TITLE
Fix #500: [BUG]: TSP devices don't check for a `write_termination` cha

### DIFF
--- a/src/tm_devices/driver_mixins/device_control/tsp_control.py
+++ b/src/tm_devices/driver_mixins/device_control/tsp_control.py
@@ -180,8 +180,11 @@ class TSPControl(PIControl, ABC):
         # Check if the script exists, delete it if it does
         self.write(f"if {script_name} ~= nil then script.delete('{script_name}') end")
 
-        # Load the script
-        self.write(f"loadscript {script_name}\n{script_body}\nendscript")
+        # Load the script, writing each line separately to avoid exceeding the
+        # 1000-character write limit of TSP devices.
+        script_lines = [f"loadscript {script_name}", *script_body.splitlines(), "endscript"]
+        for line in script_lines:
+            self.write(line)
 
         # Save to Non-Volatile Memory (script definition survives power cycle)
         if to_nv_memory:

--- a/tests/sim_devices/smu/smu2601b.yaml
+++ b/tests/sim_devices/smu/smu2601b.yaml
@@ -7,8 +7,14 @@ devices:
         r: Keithley Instruments Inc., Model 2601B, 4498311, 3.3.5
       - q: print(available(gpib))
         r: 'true'
-      - q: loadscript loadfuncs\n-- Sample script used in test_smu.py.\nprint("TEK")\nendscript
-      - q: loadscript tsp_function\n-- Sample script used in test_smu.py.\nprint("TEK")\nendscript
+      - q: loadscript loadfuncs
+      - q: '-- Sample script used in test_smu.py.'
+      - q: print("TEK")
+      - q: endscript
+      - q: loadscript tsp_function
+      - q: '-- Sample script used in test_smu.py.'
+      - q: print("TEK")
+      - q: endscript
       - q: loadfuncs.save()
       - q: loadfuncs()
       - q: errorqueue.clear()


### PR DESCRIPTION
## Summary

Addresses: #500

This PR addresses the issue: **[BUG]: TSP devices don't check for a `write_termination` character when loading a script**

### Analysis

- **Solvability**: likely_solvable (confidence: 75%)
- **Complexity**: medium
- **Reasoning**: The issue has a clear bug description and reproduction steps showing that `load_script()` doesn't validate write length against the 1000-character limit before adding the write_termination character. The fix likely involves checking script length and splitting into multiple writes if needed, but requires understanding the codebase structure, TSP device protocol details, and existing script-loading implementation to implement correctly.

### Changes

```
src/tm_devices/driver_mixins/device_control/tsp_control.py |  7 +++++--
 tests/sim_devices/smu/smu2601b.yaml                        | 10 ++++++++--
 2 files changed, 13 insertions(+), 4 deletions(-)
```

### Test Results

```
============================= test session starts ==============================
platform linux -- Python 3.11.11, pytest-9.0.2, pluggy-1.6.0 -- /home/alairjt/.pyenv/versions/3.11.11/bin/python
cachedir: .pytest_cache
rootdir: /tmp/issue-resolver-workspaces/tektronix-tm_devices-b101923d6667
configfile: pyproject.toml
plugins: django-4.9.0, mock-3.14.1, timeout-2.4.0, Faker-38.0.0, cov-6.0.0, asyncio-1.3.0, bdd-8.1.0, anyio-4.10.0, xdist-3.8.0, order-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 782 items

tests/test_abstract_device_expect_esr.py::test_expect_esr_param_just_esr_arg PASSED [  0%]
tests/test_afgs.py::test_afg3k PASSED                                    [  0%]
tests/test_afgs.py::test_afg31k PASSED                                   [  0%]
tests/test_alias_dict.py::test_alias_dict PASSED                         [  0%]
tests/test_all_device_drivers.py::test_device_driver[AFG-AFG3051-HOSTNAME-None-None-None] PASSED [  0%]
tests/test_all_device_drivers.py::test_device_driver[AFG-AFG3022B-HOSTNAME-None-None-None] PASSED [  0%]
tests/test_all_device_drivers.py::test_device_driver[AFG-AFG3252C-HOSTNAME-10001-SOCKET-None] PASSED [  0%]
tests/test_all_device_drivers.py::test_device_driver[AFG-AFG31021-HOSTNAME-None-None-None] PASSED [  1%]
tests/test_all_device_drivers.py::test_device_driver[AWG-AWG5200OPT50-HOSTNAME-None-None-None] PASSED [  1%]
tests/test_all_device_drivers.py::test_device_driver[AWG-AWG5012-HOSTNAME-None-None-None] PASSED [  1%]
tests/test_all_device_drivers.py::test_device_driver[AWG-AWG5002B-HOSTNAME-None-None-None] PASSED [  1%]
tests/test_all_device_drivers.py::test_device_driver[AWG-AWG5012C-HOSTNAME-None-None-None] PASSED [  1%]
tests/test_all_device_drivers.py::test_device_driver[AWG-AWG7051OPT01-HOSTNAME-None-None-None] PASSED [  1%]
tests/test_all_device_drivers.py::test_device_driver[AWG-AWG7062BOPT02-HOSTNAME-None-None-None] P
... (truncated)
```

---
*Generated by [issue-resolver](https://github.com/suportly/issue-resolver) | Cost: $1.27*