### PR TITLE
fix: Properly set each device's `enable_verification` property when connecting to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Things to be included in the next release go here.
 - Enable programmatic connection to devices that use a different LAN device endpoint via the `DeviceManager`.
 - Added support for Python 3.14.
 
+### Fixed
+
+- Fixed the bug causing devices to not properly inherit the `DeviceManager`'s command verification setting for all connection methods (config file, environment variable, python code).
+
 ### Changed
 
 - _**<span style="color:orange">minor breaking change</span>**_: Changed the `lan_device_name` parameter name to `lan_device_endpoint` to be more accurate.

--- a/src/tm_devices/device_manager.py
+++ b/src/tm_devices/device_manager.py
@@ -1504,6 +1504,9 @@ class DeviceManager(metaclass=Singleton):
         if self.__setup_cleanup_enabled:
             new_device.cleanup(verbose=bool(self.__config.options.verbose_mode))
 
+        # Set the device command verification based on the DeviceManager option for it.
+        new_device.enable_verification = not bool(self.__disable_command_verification)
+
         return new_device
 
     def __protect_access(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,10 +148,12 @@ def _reset_dm(  # pyright: ignore[reportUnusedFunction]
     """
     saved_setup_enable = device_manager.setup_cleanup_enabled
     saved_teardown_enable = device_manager.teardown_cleanup_enabled
+    saved_disable_command_verification = device_manager.disable_command_verification
     device_manager.remove_all_devices()
     yield
     device_manager.setup_cleanup_enabled = saved_setup_enable
     device_manager.teardown_cleanup_enabled = saved_teardown_enable
+    device_manager.disable_command_verification = saved_disable_command_verification
     device_manager.load_config_file(unit_test_config_file)
 
 

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -49,6 +49,9 @@ class TestDeviceManager:  # pylint: disable=no-self-use
         """
         # use a serial device for coverage with updating visa_object serial settings.
         device_manager.remove_all_devices()
+        device_manager.disable_command_verification = False
+        device_manager.setup_cleanup_enabled = False
+        device_manager.teardown_cleanup_enabled = False
         device_manager.add_smu(
             "1",
             alias="testing",
@@ -93,6 +96,7 @@ device_type = "SCOPE"
 
 [options]
 default_visa_timeout = {UNIT_TEST_TIMEOUT}
+disable_command_verification = false
 setup_cleanup = false
 standalone = false
 teardown_cleanup = false
@@ -122,6 +126,7 @@ devices:
     device_type: SCOPE
 options:
   default_visa_timeout: {UNIT_TEST_TIMEOUT}
+  disable_command_verification: false
   setup_cleanup: false
   standalone: false
   teardown_cleanup: false


### PR DESCRIPTION
## Proposed changes

fix: Properly set each device's `enable_verification` property when connecting to it

Addresses #556 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
