### PR TITLE
fix: Removed 10 mV tolerance for offset and amplitude in AFGSourceChannel.set_function_properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Things to be included in the next release go here.
 ### Fixed
 
 - Fixed the bug causing devices to not properly inherit the `DeviceManager`'s command verification setting for all connection methods (config file, environment variable, python code).
+- Fixed the bug in `AFGSourceChannel.set_function_properties` where amplitude and offset updates within 10 mV were ignored on consecutive calls.
 
 ### Changed
 

--- a/src/tm_devices/drivers/afgs/afg.py
+++ b/src/tm_devices/drivers/afgs/afg.py
@@ -323,7 +323,7 @@ class AFGSourceChannel(BaseAFGSourceChannel):
         # Frequency
         self.set_frequency(frequency)
         # Offset
-        self.set_offset(offset, absolute_tolerance=0.01)
+        self.set_offset(offset)
         if function == SignalGeneratorFunctionsAFG.PULSE:
             # Duty cycle is only valid for pulse
             self.set_pulse_duty_cycle(duty_cycle)
@@ -334,7 +334,7 @@ class AFGSourceChannel(BaseAFGSourceChannel):
             self.set_ramp_symmetry(symmetry)
         self.set_function(function)
         # Amplitude, needs to be after termination so that the amplitude is properly adjusted
-        self.set_amplitude(amplitude, absolute_tolerance=0.01)
+        self.set_amplitude(amplitude)
         if burst_count > 0:
             self.setup_burst_waveform(burst_count)
 


### PR DESCRIPTION
## Proposed changes

Please include a summary of the changes and any links to related issues. Please also include relevant motivation and context.

Addresses #565 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [ ] I have signed the CLA
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [X] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [X] I have performed a self-review of my code
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] Basic linting passes locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have added necessary documentation (if appropriate)
- [X] I have updated the Changelog with a brief description of my changes
