### PR TITLE
docs: Update CHANGELOG formatting to comply with pre-commit checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,19 @@ Valid subsections within a version are:
 
 Things to be included in the next release go here.
 
+### Fixed
+
+- Updated the changelog to pass `pre-commit` checks.
+
 ---
 
 ## v3.6.1 (2026-04-14)
 
 ### Merged Pull Requests
 
-- docs: Add fix for scope.commands.ch[<channel>].probe.selfcal.state.query() EXECUTE status ([#573](https://github.com/tektronix/tm_devices/pull/573))
+- docs: Add fix for scope.commands.ch\[<channel>\].probe.selfcal.state.query() EXECUTE status ([#573](https://github.com/tektronix/tm_devices/pull/573))
 - docs: Add probe selfcal.state.query() fix to CHANGELOG ([#572](https://github.com/tektronix/tm_devices/pull/572))
-- fix: Updated EXECUTE in scope.commands.ch[<channel>].probe.selfcal.state.query() ([#8](https://github.com/tektronix/tm_devices/pull/8))
+- fix: Updated EXECUTE in scope.commands.ch\[<channel>\].probe.selfcal.state.query() ([#8](https://github.com/tektronix/tm_devices/pull/8))
 - gh-actions(deps): bump the gh-actions-dependencies group with 12 updates ([#569](https://github.com/tektronix/tm_devices/pull/569))
 - python-deps(deps): bump the python-dependencies group with 6 updates ([#570](https://github.com/tektronix/tm_devices/pull/570))
 


### PR DESCRIPTION
## Proposed changes

docs: Update CHANGELOG formatting to comply with pre-commit checks

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [x] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [ ] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
