### PR TITLE
fix: validate TSP loadscript write spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Things to be included in the next release go here.
 ### Fixed
 
 - Updated the changelog to pass `pre-commit` checks.
+- Updated TSP script loading to write each line with a termination and reject script lines
+    that exceed the instrument input limit.
 
 ---
 

--- a/src/tm_devices/driver_mixins/device_control/tsp_control.py
+++ b/src/tm_devices/driver_mixins/device_control/tsp_control.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
+_MAX_TSP_WRITE_CHARS = 1000
+
 
 class TSPControl(PIControl, ABC):
     """Base Test Script Processing (TSP) control class.
@@ -177,11 +179,14 @@ class TSPControl(PIControl, ABC):
             # script_body argument is overwritten by file contents
             script_body = Path(file_path).read_text(encoding="utf-8").strip()
 
+        load_script_command = f"loadscript {script_name}\n{script_body}\nendscript"
+        _validate_tsp_write_termination_spans(load_script_command)
+
         # Check if the script exists, delete it if it does
         self.write(f"if {script_name} ~= nil then script.delete('{script_name}') end")
 
         # Load the script
-        self.write(f"loadscript {script_name}\n{script_body}\nendscript")
+        self.write(load_script_command)
 
         # Save to Non-Volatile Memory (script definition survives power cycle)
         if to_nv_memory:
@@ -286,3 +291,15 @@ class TSPControl(PIControl, ABC):
         for buffer_name in self._user_created_custom_buffers:
             self.write(f"{buffer_name} = nil")
         self.write("collectgarbage()")
+
+
+def _validate_tsp_write_termination_spans(command: str) -> None:
+    """Verify that a TSP loadscript command is terminated before the input limit."""
+    for segment_number, segment in enumerate(command.split("\n"), start=1):
+        if len(segment) > _MAX_TSP_WRITE_CHARS:
+            msg = (
+                f"Segment {segment_number} in the TSP loadscript command has "
+                f"{len(segment)} characters, which exceeds the {_MAX_TSP_WRITE_CHARS} "
+                "character limit before a write termination."
+            )
+            raise ValueError(msg)

--- a/tests/test_smu.py
+++ b/tests/test_smu.py
@@ -16,6 +16,9 @@ from packaging.version import Version
 
 from conftest import UNIT_TEST_TIMEOUT
 from tm_devices import DeviceManager
+from tm_devices.driver_mixins.device_control.tsp_control import (
+    _validate_tsp_write_termination_spans,
+)
 
 if TYPE_CHECKING:
     from tm_devices.drivers import SMU2401, SMU2460, SMU2601B, SMU6430
@@ -91,6 +94,17 @@ def test_smu(  # noqa: PLR0915
     assert "loadfuncs.save()" not in stdout
     assert "loadfuncs()" in stdout
     smu.expect_esr(0)
+    _validate_tsp_write_termination_spans(f"loadscript max_line_script\n{('x' * 1000)}\nendscript")
+
+    too_long_script_line = f"print({('x' * 992)!r})"
+    _ = capsys.readouterr()
+    with pytest.raises(
+        ValueError,
+        match="Segment 2 in the TSP loadscript command has 1001 characters",
+    ):
+        smu.load_script(script_name="too_long_script", script_body=too_long_script_line)
+    stdout = capsys.readouterr().out
+    assert "too_long_script" not in stdout
 
     with mock.patch("pyvisa.highlevel.VisaLibraryBase.clear", mock.MagicMock(return_value=None)):
         assert smu.query_expect_timeout("INVALID?", timeout_ms=1) == ""


### PR DESCRIPTION
This fixes #500 by checking the full loadscript command before it is sent to the instrument. The existing single-write behavior is kept, but the code now rejects any newline-delimited span longer than the TSP input limit, so a script line cannot run past the required write termination point. The check happens before the old script is deleted, so an invalid script body does not leave the device half-updated.

I added coverage in the SMU test for the 1000-character boundary and for rejecting the over-limit case before a write is sent. I also updated the unreleased changelog.

Tested locally on Windows with Python 3.14:
- poetry run pytest tests/test_smu.py -q
- poetry run pytest -q -k "not test_docs"
- poetry run ruff format --check .
- poetry run ruff check .
- poetry run pyright

I also tried pre-commit run --all-files, but it did not finish locally even after a longer timeout, so I did not count that as passing.
