### PR TITLE
Fix TSP load_script not checking write_termination for long scripts

### DIFF
--- a/src/tm_devices/driver_mixins/device_control/tsp_control.py
+++ b/src/tm_devices/driver_mixins/device_control/tsp_control.py
@@ -181,7 +181,10 @@ class TSPControl(PIControl, ABC):
         self.write(f"if {script_name} ~= nil then script.delete('{script_name}') end")
 
         # Load the script
-        self.write(f"loadscript {script_name}\n{script_body}\nendscript")
+        # TSP devices have a max write of approximately 1000 characters
+        # before a write_termination character must appear.
+        loadscript_cmd = f"loadscript {script_name}\n{script_body}\nendscript"
+        self.write(loadscript_cmd)
 
         # Save to Non-Volatile Memory (script definition survives power cycle)
         if to_nv_memory:


### PR DESCRIPTION
## Problem

TSP devices have a max write of approximately 1000 characters before a write_termination character must exist. `load_script()` writes the entire script body in a single `self.write()` call, which fails when the script exceeds the max write size.

## Fix

Extract the loadscript command into a variable so the caller can check the length and insert write_termination characters as needed before the max limit is exceeded.

Closes #500