### PR TITLE
Fix burst mode not disabled when generating non-burst signals

### DIFF
--- a/src/tm_devices/drivers/afgs/afg.py
+++ b/src/tm_devices/drivers/afgs/afg.py
@@ -337,6 +337,8 @@ class AFGSourceChannel(BaseAFGSourceChannel):
         self.set_amplitude(amplitude)
         if burst_count > 0:
             self.setup_burst_waveform(burst_count)
+        else:
+            self.set_burst_state(0)
 
     def set_amplitude(self, value: float, absolute_tolerance: float = 0) -> None:
         """Set the amplitude on the source channel.


### PR DESCRIPTION
## Problem

When generating a burst signal on an AFG followed by a non-burst signal via `generate_function`, the burst state is not reset. The non-burst signal remains affected by the previous burst settings, producing incorrect output.

## Fix

Add an `else` branch to `set_function_properties` to disable burst state when `burst_count` is 0.

Closes #440