### PR TITLE
fix: validate TSP load script write termination

### DIFF
--- a/src/tm_devices/driver_mixins/device_control/tsp_control.py
+++ b/src/tm_devices/driver_mixins/device_control/tsp_control.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
+_TSP_MAX_WRITE_CHARS_BEFORE_TERMINATION = 1000
+
 
 class TSPControl(PIControl, ABC):
     """Base Test Script Processing (TSP) control class.
@@ -177,11 +179,23 @@ class TSPControl(PIControl, ABC):
             # script_body argument is overwritten by file contents
             script_body = Path(file_path).read_text(encoding="utf-8").strip()
 
+        # Load the script
+        load_script_command = f"loadscript {script_name}\n{script_body}\nendscript"
+        visa_resource = getattr(self, "_visa_resource", None)
+        write_termination = getattr(visa_resource, "write_termination", None) or "\n"
+        for command_part in load_script_command.split(write_termination):
+            if len(command_part) > _TSP_MAX_WRITE_CHARS_BEFORE_TERMINATION:
+                msg = (
+                    "TSP scripts must contain a write termination character at least every "
+                    f"{_TSP_MAX_WRITE_CHARS_BEFORE_TERMINATION} characters. "
+                    "Split long script lines before calling load_script()."
+                )
+                raise ValueError(msg)
+
         # Check if the script exists, delete it if it does
         self.write(f"if {script_name} ~= nil then script.delete('{script_name}') end")
 
-        # Load the script
-        self.write(f"loadscript {script_name}\n{script_body}\nendscript")
+        self.write(load_script_command)
 
         # Save to Non-Volatile Memory (script definition survives power cycle)
         if to_nv_memory:

--- a/tests/test_smu.py
+++ b/tests/test_smu.py
@@ -92,6 +92,12 @@ def test_smu(  # noqa: PLR0915
     assert "loadfuncs()" in stdout
     smu.expect_esr(0)
 
+    capsys.readouterr()
+    with pytest.raises(ValueError, match="write termination character"):
+        smu.load_script(script_name="overrun", script_body="x" * 1001)
+    stdout = capsys.readouterr().out
+    assert "loadscript overrun" not in stdout
+
     with mock.patch("pyvisa.highlevel.VisaLibraryBase.clear", mock.MagicMock(return_value=None)):
         assert smu.query_expect_timeout("INVALID?", timeout_ms=1) == ""
     with (


### PR DESCRIPTION
## Summary
- Validate TSP `load_script()` payloads before writing them to the instrument.
- Raise a clear `ValueError` when any command segment exceeds the 1000-character limit without a write termination character.
- Add regression coverage to ensure overlong script bodies are rejected before `loadscript` is written.

Closes #500

## Testing
- [x] `.venv/bin/python -m pytest tests/test_smu.py -q`
- [x] `.venv/bin/python -m ruff check src/tm_devices/driver_mixins/device_control/tsp_control.py tests/test_smu.py`
- [x] `.venv/bin/python -m ruff format --check src/tm_devices/driver_mixins/device_control/tsp_control.py tests/test_smu.py`
