### PR TITLE
fix: validate TSP script write termination limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Things to be included in the next release go here.
 
 ### Fixed
 
+- Fixed TSP script loading to reject lines that exceed the device's 1000-character write limit.
 - Updated the changelog to pass `pre-commit` checks.
 
 ---

--- a/src/tm_devices/driver_mixins/device_control/tsp_control.py
+++ b/src/tm_devices/driver_mixins/device_control/tsp_control.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 
 _logger: logging.Logger = logging.getLogger(__name__)
+_SCRIPT_LINE_CHARACTER_LIMIT = 1000
 
 
 class TSPControl(PIControl, ABC):
@@ -176,6 +177,17 @@ class TSPControl(PIControl, ABC):
         if file_path is not None:
             # script_body argument is overwritten by file contents
             script_body = Path(file_path).read_text(encoding="utf-8").strip()
+
+        write_termination = self.visa_resource.write_termination or "\n"
+        if any(
+            len(segment) > _SCRIPT_LINE_CHARACTER_LIMIT
+            for segment in script_body.split(write_termination)
+        ):
+            msg = (
+                "The script body must contain a write termination within every "
+                f"{_SCRIPT_LINE_CHARACTER_LIMIT} characters."
+            )
+            raise ValueError(msg)
 
         # Check if the script exists, delete it if it does
         self.write(f"if {script_name} ~= nil then script.delete('{script_name}') end")

--- a/tests/test_smu.py
+++ b/tests/test_smu.py
@@ -21,6 +21,38 @@ if TYPE_CHECKING:
     from tm_devices.drivers import SMU2401, SMU2460, SMU2601B, SMU6430
 
 
+def test_load_script_rejects_line_over_character_limit(
+    device_manager: DeviceManager,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verify TSP scripts require a write termination within 1000 characters."""
+    smu = device_manager.add_smu("smu2601b-hostname")
+    _ = capsys.readouterr()
+
+    with (
+        mock.patch.object(smu, "write") as write,
+        pytest.raises(ValueError, match=r"write termination.*1000"),
+    ):
+        smu.load_script("overrun", script_body="x" * 1001)
+
+    write.assert_not_called()
+    assert "script.delete" not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("script_body", ["x" * 1000, f"{'x' * 600}\n{'y' * 600}"])
+def test_load_script_accepts_terminated_lines_within_character_limit(
+    device_manager: DeviceManager,
+    script_body: str,
+) -> None:
+    """Verify the limit applies between terminations, not to the whole script."""
+    smu = device_manager.add_smu("smu2601b-hostname")
+
+    with mock.patch.object(smu, "write") as write:
+        smu.load_script("within_limit", script_body=script_body)
+
+    assert write.call_count == 2
+
+
 # pylint: disable=too-many-locals
 def test_smu(  # noqa: PLR0915
     device_manager: DeviceManager,


### PR DESCRIPTION
## Proposed changes

- Validate that TSP script lines do not exceed the device's 1000-character write limit.
- Perform validation before deleting or loading a script so invalid input causes no device writes.
- Cover the over-limit, exact-limit, and terminated multi-line cases.

Addresses #500.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/tm_devices/blob/main/CONTRIBUTING.md) document
- [ ] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/tm_devices/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/tm_devices/issues) to track the status of this update/change and updated the link in this PR description using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes

## Testing

- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_smu.py -q`
- `PYTHONPATH=src .venv/bin/python -m pytest -q -k 'not test_afg3k'`
- `.venv/bin/ruff check src/tm_devices/driver_mixins/device_control/tsp_control.py tests/test_smu.py`
- `.venv/bin/ruff format --check src/tm_devices/driver_mixins/device_control/tsp_control.py tests/test_smu.py`
- `git diff --check`

The unfiltered suite has one unrelated baseline failure in `tests/test_afgs.py::test_afg3k`: PyVISA-sim 0.7.1 reports its simulated library path as `unset`, while the existing backend-name detection expects the older `.yaml` path. The test fails independently of this patch.

## AI assistance

This change was developed with assistance from OpenAI Codex and reviewed through local tests and static checks.